### PR TITLE
Fixing streamable accept header filter

### DIFF
--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/McpMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/McpMessageHandler.java
@@ -46,7 +46,7 @@ public class McpMessageHandler {
         capabilities.put("prompts", Map.of());
         capabilities.put("tools", Map.of());
         capabilities.put("resources", Map.of());
-        capabilities.put("logging", Map.of());
+//        capabilities.put("logging", Map.of());
         this.serverInfo.put("capabilities", capabilities);
     }
 

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/StreamableHttpHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/StreamableHttpHandler.java
@@ -50,8 +50,7 @@ public class StreamableHttpHandler implements HttpHandler {
             return;
         }
         HeaderValues accepts = exchange.getRequestHeaders().get(Headers.ACCEPT);
-        if (!accepts.contains("application/json")
-                || !accepts.contains("text/event-stream")) {
+        if (!isValideAcceptHeader(accepts)) {
             MCPLogger.ROOT_LOGGER.invalidAcceptHeaders(Arrays.toString(accepts.toArray()));
             exchange.setStatusCode(400);
             exchange.endExchange();
@@ -90,4 +89,12 @@ public class StreamableHttpHandler implements HttpHandler {
         handler.handle(content, connection, connection);
     }
 
+    private boolean isValideAcceptHeader(HeaderValues accepts) {
+        for (String accept : accepts) {
+            if (accept.contains("application/json") && accept.contains("text/event-stream")) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
log is not a supported capability, removing it from the initialize message