### PR TITLE
chore: run MCP integration tests by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <version.org.wildfly.core>31.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>8.1.0.Final</version.org.wildfly.galleon-plugins>
+        <version.wildfly.maven.plugin>5.1.5.Final</version.wildfly.maven.plugin>
 
         <version.ai.djl>0.33.0</version.ai.djl>
         <version.com.azure.azure-ai-inference>1.0.0-beta.5</version.com.azure.azure-ai-inference>
@@ -1080,15 +1081,6 @@
         <module>wildfly-wasm</module>
         <module>wildfly-mcp</module>
         <module>ai-feature-pack</module>
+        <module>testsuite</module>
     </modules>
-
-    <profiles>
-        <!-- Profile to run integration tests -->
-        <profile>
-            <id>integration-test</id>
-            <modules>
-                <module>testsuite</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>

--- a/testsuite/integration/README.md
+++ b/testsuite/integration/README.md
@@ -21,10 +21,10 @@ The integration tests automatically manage containers using Testcontainers, elim
 
 ### From Maven
 
-Run integration tests with the `integration-test` profile:
+Run integration tests:
 
 ```bash
-mvn clean verify -Pintegration-test
+mvn clean verify
 ```
 
 ### From IDE
@@ -114,7 +114,7 @@ podman run -d -p 11434:11434 ollama/ollama
 podman exec <container-name> ollama pull llama3.2:1b
 
 # Run tests - will use existing instance
-mvn verify -Pintegration-test
+mvn verify
 ```
 
 ### LGTM (OpenTelemetry Testing)
@@ -124,7 +124,7 @@ docker run -d -p 3000:3000 -p 4318:4318 -p 9090:9090 \
   --name lgtm grafana/otel-lgtm:0.17.1
 
 # Run tests - OpenTelemetry tests will use existing instance
-mvn verify -Pintegration-test
+mvn verify
 ```
 
 Container managers will detect local instances and use them, providing faster test execution and persistent state between runs.

--- a/testsuite/integration/README.md
+++ b/testsuite/integration/README.md
@@ -21,10 +21,10 @@ The integration tests automatically manage containers using Testcontainers, elim
 
 ### From Maven
 
-Run integration tests:
+Run integration tests with the `integration-test` Maven profile:
 
 ```bash
-mvn clean verify
+mvn clean verify -Pintegration-test
 ```
 
 ### From IDE
@@ -114,7 +114,7 @@ podman run -d -p 11434:11434 ollama/ollama
 podman exec <container-name> ollama pull llama3.2:1b
 
 # Run tests - will use existing instance
-mvn verify
+mvn verify -Pintegration-test
 ```
 
 ### LGTM (OpenTelemetry Testing)
@@ -124,7 +124,7 @@ docker run -d -p 3000:3000 -p 4318:4318 -p 9090:9090 \
   --name lgtm grafana/otel-lgtm:0.17.1
 
 # Run tests - OpenTelemetry tests will use existing instance
-mvn verify
+mvn verify -Pintegration-test
 ```
 
 Container managers will detect local instances and use them, providing faster test execution and persistent state between runs.

--- a/testsuite/integration/extra-content/standalone/configuration/configure-opentelemetry.cli
+++ b/testsuite/integration/extra-content/standalone/configuration/configure-opentelemetry.cli
@@ -1,7 +1,7 @@
 # CLI script to configure OpenTelemetry subsystem for testing
 # This configures WildFly to send traces and metrics to the LGTM container
 
-embed-server --server-config=standalone.xml
+embed-server --server-config=standalone.xml --stability=experimental
 
 # Add OpenTelemetry subsystem if not already present
 if (outcome != success) of /subsystem=opentelemetry:read-resource

--- a/testsuite/integration/extra-content/standalone/configuration/logging.properties
+++ b/testsuite/integration/extra-content/standalone/configuration/logging.properties
@@ -1,2 +1,0 @@
-# Additional logging configuration for AI subsystem debugging
-logger.org.wildfly.extension.ai.level=DEBUG

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.generative-ai</groupId>
         <artifactId>wildfly-ai-testsuite</artifactId>
-        <version>0.10.0-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wildfly-ai-testsuite-integration</artifactId>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -19,7 +19,6 @@
         <version.wildfly.arquillian>5.1.0.Final</version.wildfly.arquillian>
         <version.testcontainers>1.21.4</version.testcontainers>
         <version.wildfly.glow>1.5.2.Final</version.wildfly.glow>
-        <version.wildfly.maven.plugin>5.1.0.Final</version.wildfly.maven.plugin>
         <version.maven.surefire>3.5.3</version.maven.surefire>
         <jboss.home>${project.build.directory}/server</jboss.home>
 
@@ -205,12 +204,13 @@
                 <version>${version.wildfly.maven.plugin}</version>
                 <executions>
                     <execution>
-                        <id>provision-server</id>
+                        <id>provision-server-otel</id>
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>provision</goal>
                         </goals>
                         <configuration>
+                            <stability>experimental</stability>
                             <provisioning-file>${project.build.testOutputDirectory}/provisioning-otel.xml</provisioning-file>
                             <provisioningDir>${project.build.directory}/server-otel</provisioningDir>
                             <extraServerContentDirs>extra-content</extraServerContentDirs>
@@ -227,21 +227,22 @@
                         </goals>
                         <configuration>
                             <jboss-home>${project.build.directory}/server-otel</jboss-home>
+                            <stability>experimental</stability>
                             <offline>true</offline>
                             <scripts>
-                                <script>${project.build.directory}/server/standalone/configuration/configure-opentelemetry.cli</script>
+                                <script>${project.build.directory}/server-otel/standalone/configuration/configure-opentelemetry.cli</script>
                             </scripts>
                         </configuration>
                     </execution>
-
                     <!-- Provision the default server without OpenTelemetry layer (observable=false) -->
                     <execution>
-                        <id>provision-server-otel</id>
+                        <id>provision-server</id>
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>provision</goal>
                         </goals>
                         <configuration>
+                            <stability>experimental</stability>
                             <provisioning-file>${project.build.testOutputDirectory}/provisioning.xml</provisioning-file>
                             <galleon-options>
                                 <jboss-fork-embedded>true</jboss-fork-embedded>
@@ -269,6 +270,9 @@
                                 <resource>
                                     <directory>${project.basedir}/extra-content</directory>
                                     <filtering>false</filtering>
+                                    <excludes>
+                                        <exclude>**/*.cli</exclude>
+                                    </excludes>
                                 </resource>
                             </resources>
                         </configuration>
@@ -287,9 +291,6 @@
                                 <resource>
                                     <directory>${project.basedir}/extra-content</directory>
                                     <filtering>false</filtering>
-                                    <excludes>
-                                        <exclude>**/*.cli</exclude>
-                                    </excludes>
                                 </resource>
                             </resources>
                         </configuration>

--- a/testsuite/integration/src/test/resources/arquillian.xml
+++ b/testsuite/integration/src/test/resources/arquillian.xml
@@ -11,6 +11,7 @@
                 <property name="managementPort">9990</property>
                 <property name="startupTimeoutInSeconds">120</property>
                 <property name="allowConnectingToRunningServer">false</property>
+                <property name="jbossArguments">--stability=experimental</property>
                 <property name="javaVmArguments">
                     -Dorg.wildfly.ai.ollama.chat.url=${ollama.base.url:http://127.0.0.1:11434}
                     -Dorg.wildfly.ai.ollama.embedding.url=${ollama.base.url:http://127.0.0.1:11434}
@@ -27,6 +28,7 @@
                 <property name="managementPort">10090</property>
                 <property name="startupTimeoutInSeconds">120</property>
                 <property name="allowConnectingToRunningServer">false</property>
+                <property name="jbossArguments">--stability=experimental</property>
                 <property name="javaVmArguments">
                     -Djboss.socket.binding.port-offset=100
                     -Dorg.wildfly.ai.ollama.chat.url=${ollama.base.url:http://127.0.0.1:11434}

--- a/testsuite/integration/src/test/resources/provisioning-otel.xml
+++ b/testsuite/integration/src/test/resources/provisioning-otel.xml
@@ -12,7 +12,7 @@
         <layers>
             <!-- Base WildFly layers -->
             <include name="cdi"/>
-            <include name="jaxrs"/>
+            <include name="jaxrs-server"/>
             <include name="management"/>
             <include name="opentelemetry"/>
 

--- a/testsuite/integration/src/test/resources/provisioning.xml
+++ b/testsuite/integration/src/test/resources/provisioning.xml
@@ -12,9 +12,8 @@
         <layers>
             <!-- Base WildFly layers (no opentelemetry) -->
             <include name="cdi"/>
-            <include name="jaxrs"/>
+            <include name="jaxrs-server"/>
             <include name="management"/>
-
             <!-- AI Feature Pack layers for testing -->
             <include name="ollama-chat-model"/>
             <include name="ollama-streaming-chat-model"/>

--- a/testsuite/mcp/pom.xml
+++ b/testsuite/mcp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.generative-ai</groupId>
         <artifactId>wildfly-ai-testsuite</artifactId>
-        <version>0.10.0-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wildfly-ai-testsuite-mcp</artifactId>

--- a/testsuite/mcp/pom.xml
+++ b/testsuite/mcp/pom.xml
@@ -19,7 +19,6 @@
         <version.arquillian>1.10.0.Final</version.arquillian>
         <version.wildfly.arquillian>5.1.0.Final</version.wildfly.arquillian>
         <version.assertj>3.26.3</version.assertj>
-        <version.wildfly.maven.plugin>5.1.0.Final</version.wildfly.maven.plugin>
         <version.maven.surefire>3.5.2</version.maven.surefire>
         <jboss.home>${project.build.directory}/server</jboss.home>
     </properties>
@@ -151,7 +150,7 @@
                         </goals>
                         <configuration>
                             <provisioning-file>${project.build.testOutputDirectory}/provisioning.xml</provisioning-file>
-                            <stability-level>experimental</stability-level>
+                            <stability>experimental</stability>
                             <galleon-options>
                                 <jboss-fork-embedded>true</jboss-fork-embedded>
                             </galleon-options>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.generative-ai</groupId>
         <artifactId>wildfly-ai-feature-pack-parent</artifactId>
-        <version>0.10.0-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wildfly-ai-testsuite</artifactId>
@@ -13,6 +13,10 @@
 
     <name>WildFly AI Feature Pack - Testsuite</name>
     <description>Integration testsuite for the WildFly AI Feature Pack</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 
     <modules>
         <module>mcp</module>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -15,8 +15,19 @@
     <description>Integration testsuite for the WildFly AI Feature Pack</description>
 
     <modules>
-        <module>integration</module>
         <module>mcp</module>
     </modules>
 
+    <profiles>
+        <!-- Profile to run integration tests -->
+        <!-- They are disabled by default, as they require more CPUs that
+             what can be provided by GitHub Actions.
+        -->
+        <profile>
+            <id>integration-test</id>
+            <modules>
+                <module>integration</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
* The test suite requires to provision and run WildFly at the experimental stability level
* Provision the jaxrs-server instead of jaxrs to provision
  a fully functional server (otherwise, it was missing logging
  subsystem for example)
* Remove the logging.properties that overrides the one that is provisioned
  (if we really want the log, we can execute a cli script during provisioning)

By default, the testsuite/mcp module is enabled.
As the testsuite/integration module requires additional resources, it is disabled
by defaut and requires the `integration-test` Maven profile to be executed.

This PR is built on top of #243.
