### PR TITLE
fix: use MCPLogger message definitions for all INFO+ logging in MCP modules

### DIFF
--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
@@ -5,10 +5,15 @@
 
 package org.wildfly.extension.mcp.injection;
 
+import static org.jboss.logging.Logger.Level.ERROR;
+
 import java.lang.invoke.MethodHandles;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "WFMCPINJC", length = 5)
@@ -16,7 +21,8 @@ public interface MCPLogger extends BasicLogger {
 
     MCPLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MCPLogger.class, "org.wildfly.extension.mcp.injection");
 
-//    @Message(id = 1, value = "The bean name %s is expecting a %s while the llm is configured as streaming %s")
-//    IllegalStateException incorrectLLMConfiguration(String name, String typeClass, boolean streaming);
+    @LogMessage(level = ERROR)
+    @Message(id = 1, value = "Unexpected error")
+    void unexpectedError(@Cause Throwable cause);
 
 }

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/WildFlyMCPRegistry.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/WildFlyMCPRegistry.java
@@ -14,6 +14,8 @@ import java.util.regex.Pattern;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
 import org.wildfly.extension.mcp.injection.tool.MethodMetadata;
 
+import static org.wildfly.extension.mcp.injection.MCPLogger.ROOT_LOGGER;
+
 public class WildFlyMCPRegistry {
 
     /**
@@ -190,7 +192,7 @@ public class WildFlyMCPRegistry {
             MethodHandle handle = privateLookup.findVirtual(clazz, method.name(), mt);
             toolInvokers.put(toolName, handle);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException ex) {
-            MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+            ROOT_LOGGER.unexpectedError(ex);
         }
     }
 
@@ -202,7 +204,7 @@ public class WildFlyMCPRegistry {
             MethodHandle handle = privateLookup.findVirtual(clazz, method.name(), mt);
             promptInvokers.put(promptName, handle);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException ex) {
-            MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+            ROOT_LOGGER.unexpectedError(ex);
         }
     }
 
@@ -214,7 +216,7 @@ public class WildFlyMCPRegistry {
             MethodHandle handle = privateLookup.findVirtual(clazz, method.name(), mt);
             resourceInvokers.put(resourceUri, handle);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException ex) {
-            MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+            ROOT_LOGGER.unexpectedError(ex);
         }
     }
 
@@ -226,7 +228,7 @@ public class WildFlyMCPRegistry {
             MethodHandle handle = privateLookup.findVirtual(clazz, method.name(), mt);
             resourceTemplateInvokers.put(uriTemplate, handle);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException ex) {
-            MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+            ROOT_LOGGER.unexpectedError(ex);
         }
     }
 
@@ -238,7 +240,7 @@ public class WildFlyMCPRegistry {
             MethodHandle handle = privateLookup.findVirtual(clazz, method.name(), mt);
             promptCompletionInvokers.put(key, handle);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException ex) {
-            MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+            ROOT_LOGGER.unexpectedError(ex);
         }
     }
 
@@ -250,7 +252,7 @@ public class WildFlyMCPRegistry {
             MethodHandle handle = privateLookup.findVirtual(clazz, method.name(), mt);
             resourceTemplateCompletionInvokers.put(key, handle);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException ex) {
-            MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+            ROOT_LOGGER.unexpectedError(ex);
         }
     }
 }

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPPortableExtension.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPPortableExtension.java
@@ -17,6 +17,8 @@ import java.util.Set;
 import org.wildfly.extension.mcp.injection.MCPLogger;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 
+import static org.wildfly.extension.mcp.injection.MCPLogger.ROOT_LOGGER;
+
 public class MCPPortableExtension implements Extension {
     
     private final WildFlyMCPRegistry registry;
@@ -32,50 +34,50 @@ public class MCPPortableExtension implements Extension {
         Map<Class<?>, String> ids = new HashMap<>();
         for (MCPFeatureMetadata tool : registry.listTools()) {
             String className = tool.method().declaringClassName();
-            MCPLogger.ROOT_LOGGER.infof("Adding %s to CDI for discovery", className);
+            ROOT_LOGGER.debugf("Adding %s to CDI for discovery", className);
             try {
                 Class<?> clazz = Class.forName(className, true, deploymentClassLoader);
                 registry.prepareTool(tool.name(), clazz);
                 updateAnnotations(beanClasses, clazz, MCPTool.MCPToolLiteral.INSTANCE);
                 ids.putIfAbsent(clazz, tool.name() + "-" + tool.method().name());
             } catch (ClassNotFoundException ex) {
-                MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+                ROOT_LOGGER.unexpectedError(ex);
             }
         }
         for (MCPFeatureMetadata prompt : registry.listPrompts()) {
             String className = prompt.method().declaringClassName();
-            MCPLogger.ROOT_LOGGER.infof("Adding %s to CDI for discovery", className);
+            ROOT_LOGGER.debugf("Adding %s to CDI for discovery", className);
             try {
                 Class clazz = Class.forName(className, true, deploymentClassLoader);
                 registry.preparePrompt(prompt.name(), clazz);
                 updateAnnotations(beanClasses, clazz, MCPPrompt.MCPPromptLiteral.INSTANCE);
                 ids.putIfAbsent(clazz, prompt.name() + "-" + prompt.method().name());
             } catch (ClassNotFoundException ex) {
-                MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+                ROOT_LOGGER.unexpectedError(ex);
             }
         }
         for (MCPFeatureMetadata resource : registry.listResources()) {
             String className = resource.method().declaringClassName();
-            MCPLogger.ROOT_LOGGER.infof("Adding %s to CDI for discovery", className);
+            ROOT_LOGGER.debugf("Adding %s to CDI for discovery", className);
             try {
                 Class clazz = Class.forName(className, true, deploymentClassLoader);
                 registry.prepareResource(resource.method().uri(), clazz);
                 updateAnnotations(beanClasses, clazz, MCPResource.MCPResourceLiteral.INSTANCE);
                 ids.putIfAbsent(clazz, resource.method().uri() + "-" + resource.method().name());
             } catch (ClassNotFoundException ex) {
-                MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+                ROOT_LOGGER.unexpectedError(ex);
             }
         }
         for (MCPFeatureMetadata resourceTemplate : registry.listResourceTemplates()) {
             String className = resourceTemplate.method().declaringClassName();
-            MCPLogger.ROOT_LOGGER.infof("Adding %s to CDI for discovery", className);
+            ROOT_LOGGER.debugf("Adding %s to CDI for discovery", className);
             try {
                 Class clazz = Class.forName(className, true, deploymentClassLoader);
                 registry.prepareResourceTemplate(resourceTemplate.method().uri(), clazz);
                 updateAnnotations(beanClasses, clazz, MCPResource.MCPResourceLiteral.INSTANCE);
                 ids.putIfAbsent(clazz, resourceTemplate.method().uri() + "-" + resourceTemplate.method().name());
             } catch (ClassNotFoundException ex) {
-                MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+                ROOT_LOGGER.unexpectedError(ex);
             }
         }
         for (MCPFeatureMetadata completion : registry.listPromptCompletions()) {
@@ -86,7 +88,7 @@ public class MCPPortableExtension implements Extension {
                 updateAnnotations(beanClasses, clazz, MCPPrompt.MCPPromptLiteral.INSTANCE);
                 ids.putIfAbsent(clazz, completion.name() + "-" + completion.method().name());
             } catch (ClassNotFoundException ex) {
-                MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+                ROOT_LOGGER.unexpectedError(ex);
             }
         }
         for (MCPFeatureMetadata completion : registry.listResourceTemplateCompletions()) {
@@ -97,7 +99,7 @@ public class MCPPortableExtension implements Extension {
                 updateAnnotations(beanClasses, clazz, MCPResource.MCPResourceLiteral.INSTANCE);
                 ids.putIfAbsent(clazz, completion.name() + "-" + completion.method().name());
             } catch (ClassNotFoundException ex) {
-                MCPLogger.ROOT_LOGGER.error("Unexpected error ", ex);
+                ROOT_LOGGER.unexpectedError(ex);
             }
         }
         for (Map.Entry<Class<?>, Set<AnnotationLiteral>> bean : beanClasses.entrySet()) {
@@ -105,7 +107,7 @@ public class MCPPortableExtension implements Extension {
             for (AnnotationLiteral annotation : bean.getValue()) {
                 config.add(annotation);
             }
-            MCPLogger.ROOT_LOGGER.infof("%s should be discoverable by CDI", bean.getKey().getName());
+            ROOT_LOGGER.debugf("%s should be discoverable by CDI", bean.getKey().getName());
         }
     }
 

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPLogger.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPLogger.java
@@ -15,9 +15,11 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.mcp_java.server.McpLog;
 
 @MessageLogger(projectCode = "WFMCP", length = 5)
 public interface MCPLogger extends BasicLogger {
@@ -31,30 +33,71 @@ public interface MCPLogger extends BasicLogger {
     @Message(id = 2, value = "Unable to resolve annotation index for deployment unit: %s")
     DeploymentUnitProcessingException unableToResolveAnnotationIndex(DeploymentUnit deploymentUnit);
 
-//    @Message(id = 3, value = "Couldn't access the Chat Language Model called %s")
-//    OperationFailedException chatLanguageModelServiceUnavailable(String chatLanguageModelName);
-
     @LogMessage(level = INFO)
-    @Message(id = 4, value = "Registered MCP endpoint '%s' for host '%s'")
+    @Message(id = 3, value = "Registered MCP endpoint '%s' for host '%s'")
     void endpointRegistered(String path, String hostName);
 
     @LogMessage(level = INFO)
-    @Message(id = 5, value = "Unregistered MCP endpoint '%s' for host '%s'")
+    @Message(id = 4, value = "Unregistered MCP endpoint '%s' for host '%s'")
     void endpointUnregistered(String path, String hostName);
 
-//    @Message(id = 6, value = "Failed to resolve module for deployment %s")
-//    DeploymentUnitProcessingException failedToResolveModule(DeploymentUnit deploymentUnit);
-
     @LogMessage(level = ERROR)
-    @Message(id = 7, value = "Invalid Method: %s")
+    @Message(id = 5, value = "Invalid HTTP Method: %s")
     void invalidHttpMethod(String method);
 
     @LogMessage(level = ERROR)
-    @Message(id = 8, value = "Invalid Accept header: %s")
+    @Message(id = 6, value = "Invalid value for HTTP header: %s")
     void invalidAcceptHeaders(String header);
+
+    @LogMessage(level = INFO)
+    @Message(id = 7, value = "Log level set to %s [connection: %s]")
+    void logLevelSet(McpLog.LogLevel logLevel, String connectionId);
+
+    @LogMessage(level = WARN)
+    @Message(id = 8, value = "Managed executor service not available, using default executor service")
+    void managedExecutorServiceNotAvailable();
 
     @LogMessage(level = ERROR)
     @Message(id = 9, value = "Invalid MCP-Protocol-Version header: expected '%s' but got '%s'")
     void invalidProtocolVersion(String expected, String actual);
 
+    @LogMessage(level = ERROR)
+    @Message(id = 10, value = "Failure sending message")
+    void failureSendingMessage(@Cause Throwable cause);
+
+    @LogMessage(level = WARN)
+    @Message(id = 11, value = "Failed to send event to client: %s")
+    void failedToSendEvent(String data);
+
+    @LogMessage(level = WARN)
+    @Message(id = 12, value = "Elicitation request %d timed out after %d ms")
+    void elicitationTimedOut(long requestId, long timeoutMillis);
+
+    @LogMessage(level = WARN)
+    @Message(id = 13, value = "Connection id is missing: %s")
+    void connectionIdMissing(String requestPath);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 14, value = "Error invoking tool %s")
+    void errorInvokingTool(@Cause Throwable cause, String toolName);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 15, value = "Error processing MCP request")
+    void errorProcessingRequest(@Cause Throwable cause);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 16, value = "Error invoking prompt %s")
+    void errorInvokingPrompt(@Cause Throwable cause, String promptName);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 17, value = "Error invoking resource %s")
+    void errorInvokingResource(@Cause Throwable cause, String resourceUri);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 18, value = "Error invoking resource template %s")
+    void errorInvokingResourceTemplate(@Cause Throwable cause, String resourceUri);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 19, value = "Error invoking completion %s")
+    void errorInvokingCompletion(@Cause Throwable cause, String name);
 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPServerDependencyProcessor.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPServerDependencyProcessor.java
@@ -85,7 +85,7 @@ public class MCPServerDependencyProcessor implements DeploymentUnitProcessor {
             String description = annotation.value("description") != null ? annotation.value("description").asString() : "";
             MethodInfo info = annotation.target().asMethod();
             List<ArgumentMetadata> arguments = buildArguments(info, promptArg);
-            MCPLogger.ROOT_LOGGER.debugf("Prompt detected on class %s with method %s with the following annotated parameters %s", info.declaringClass(), info.name(), arguments);
+            ROOT_LOGGER.debugf("Prompt detected on class %s with method %s with the following annotated parameters %s", info.declaringClass(), info.name(), arguments);
             MCPFeatureMetadata metadata = new MCPFeatureMetadata(MCPFeatureMetadata.Kind.PROMPT,
                     name,
                     new MethodMetadata(
@@ -135,7 +135,7 @@ public class MCPServerDependencyProcessor implements DeploymentUnitProcessor {
                     }
                 }
             }
-            MCPLogger.ROOT_LOGGER.debugf("Tool detected on class %s with method %s with the following annotated parameters %s", info.declaringClass(), info.name(), arguments);
+            ROOT_LOGGER.debugf("Tool detected on class %s with method %s with the following annotated parameters %s", info.declaringClass(), info.name(), arguments);
             MCPFeatureMetadata metadata = new MCPFeatureMetadata(MCPFeatureMetadata.Kind.TOOL,
                     name,
                     new MethodMetadata(
@@ -161,7 +161,7 @@ public class MCPServerDependencyProcessor implements DeploymentUnitProcessor {
             String uri = annotation.value("uri") != null ? annotation.value("uri").asString() : "";
             String mimeType = annotation.value("mimeType") != null ? annotation.value("mimeType").asString() : "";
             MethodInfo info = annotation.target().asMethod();
-            MCPLogger.ROOT_LOGGER.debugf("Resource detected on class %s with method %s", info.declaringClass(), info.name());
+            ROOT_LOGGER.debugf("Resource detected on class %s with method %s", info.declaringClass(), info.name());
             MCPFeatureMetadata metadata = new MCPFeatureMetadata(MCPFeatureMetadata.Kind.RESOURCE,
                     name,
                     new MethodMetadata(
@@ -189,7 +189,7 @@ public class MCPServerDependencyProcessor implements DeploymentUnitProcessor {
             String mimeType = annotation.value("mimeType") != null ? annotation.value("mimeType").asString() : "";
             MethodInfo info = annotation.target().asMethod();
             List<ArgumentMetadata> arguments = buildArguments(info, resourceTemplateArg);
-            MCPLogger.ROOT_LOGGER.debugf("ResourceTemplate detected on class %s with method %s with the following annotated parameters %s", info.declaringClass(), info.name(), arguments);
+            ROOT_LOGGER.debugf("ResourceTemplate detected on class %s with method %s with the following annotated parameters %s", info.declaringClass(), info.name(), arguments);
             MCPFeatureMetadata metadata = new MCPFeatureMetadata(MCPFeatureMetadata.Kind.RESOURCE_TEMPLATE,
                     name,
                     new MethodMetadata(
@@ -226,7 +226,7 @@ public class MCPServerDependencyProcessor implements DeploymentUnitProcessor {
                 arguments.add(new ArgumentMetadata(argName, "", true, String.class));
             }
             String completionKey = promptName + "_" + argName;
-            MCPLogger.ROOT_LOGGER.debugf("CompletePrompt detected on class %s with method %s for prompt %s arg %s", info.declaringClass(), info.name(), promptName, argName);
+            ROOT_LOGGER.debugf("CompletePrompt detected on class %s with method %s for prompt %s arg %s", info.declaringClass(), info.name(), promptName, argName);
             MCPFeatureMetadata metadata = new MCPFeatureMetadata(MCPFeatureMetadata.Kind.PROMPT_COMPLETE,
                     completionKey,
                     new MethodMetadata(
@@ -263,7 +263,7 @@ public class MCPServerDependencyProcessor implements DeploymentUnitProcessor {
                 arguments.add(new ArgumentMetadata(argName, "", true, String.class));
             }
             String completionKey = templateName + "_" + argName;
-            MCPLogger.ROOT_LOGGER.debugf("CompleteResourceTemplate detected on class %s with method %s for template %s arg %s", info.declaringClass(), info.name(), templateName, argName);
+            ROOT_LOGGER.debugf("CompleteResourceTemplate detected on class %s with method %s for template %s arg %s", info.declaringClass(), info.name(), templateName, argName);
             MCPFeatureMetadata metadata = new MCPFeatureMetadata(MCPFeatureMetadata.Kind.RESOURCE_TEMPLATE_COMPLETE,
                     completionKey,
                     new MethodMetadata(

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/CompletionHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/CompletionHandler.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.extension.mcp.server;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.JsonRPC.INTERNAL_ERROR;
 import static org.wildfly.extension.mcp.api.JsonRPC.INVALID_PARAMS;
 import static org.wildfly.extension.mcp.api.JsonRPC.INVALID_REQUEST;
@@ -19,7 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
-import org.wildfly.extension.mcp.injection.MCPLogger;
+import org.wildfly.extension.mcp.MCPLogger;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPPrompt;
@@ -93,7 +94,7 @@ public class CompletionHandler {
             }
             sendCompletionResponse(id, result, responder);
         } catch (Throwable ex) {
-            MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking completion %s", metadata.name());
+            ROOT_LOGGER.errorInvokingCompletion(ex, metadata.name());
             responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
         }
     }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ElicitationSenderImpl.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ElicitationSenderImpl.java
@@ -27,6 +27,8 @@ import org.wildfly.extension.mcp.injection.elicitation.ElicitationResponse;
 import org.wildfly.extension.mcp.injection.elicitation.ElicitationSender;
 import org.wildfly.extension.mcp.injection.elicitation.PrimitiveSchema;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
+
 /**
  * Subsystem-side implementation of {@link ElicitationSender}.
  *
@@ -88,7 +90,7 @@ class ElicitationSenderImpl implements ElicitationSender {
                 .add("requestedSchema", schema);
 
         responder.send(Messages.newRequest(requestId, ELICITATION_CREATE, params));
-        MCPLogger.ROOT_LOGGER.debugf("Elicitation request sent [id: %d, message: %s]", requestId, request.message());
+        ROOT_LOGGER.debugf("Elicitation request sent [id: %d, message: %s]", requestId, request.message());
 
         // Block the tool thread until the client responds or the timeout expires
         JsonObject responseMessage;
@@ -96,7 +98,7 @@ class ElicitationSenderImpl implements ElicitationSender {
             responseMessage = future.get(request.timeoutMillis(), TimeUnit.MILLISECONDS);
         } catch (TimeoutException te) {
             registry.remove(requestId);
-            MCPLogger.ROOT_LOGGER.warnf("Elicitation request %d timed out after %d ms", requestId, request.timeoutMillis());
+            ROOT_LOGGER.elicitationTimedOut(requestId, request.timeoutMillis());
             throw te;
         }
 

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPMessageHandler.java
@@ -26,6 +26,8 @@ import org.wildfly.extension.mcp.api.Responder;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.mcp_java.server.McpLog;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
+
 public class MCPMessageHandler {
 
     private final ConnectionManager connectionManager;
@@ -111,7 +113,7 @@ public class MCPMessageHandler {
         String method = message.getString("method");
         if (NOTIFICATIONS_INITIALIZED.equals(method)) {
             if (connection.setInitialized()) {
-                MCPLogger.ROOT_LOGGER.infof("Client successfully initialized [%s]", connection.id());
+                ROOT_LOGGER.debugf("Client successfully initialized [%s]", connection.id());
             }
         } else if (PING.equals(method)) {
             ping(message, responder);
@@ -197,20 +199,20 @@ public class MCPMessageHandler {
             return;
         }
         connection.setLogLevel(logLevel);
-        MCPLogger.ROOT_LOGGER.infof("Log level set to %s [connection: %s]", logLevel, connection.id());
+        ROOT_LOGGER.logLevelSet(logLevel, connection.id());
         responder.sendResult(id, Json.createObjectBuilder());
     }
 
     private void ping(JsonObject message, Responder responder) {
         // https://spec.modelcontextprotocol.io/specification/basic/utilities/ping/
         String id = message.get("id").toString();
-        MCPLogger.ROOT_LOGGER.infof("Ping [id: %s]", id);
+        ROOT_LOGGER.debugf("Ping [id: %s]", id);
         responder.sendResult(id, Json.createObjectBuilder());
     }
 
     private void close(JsonObject message, Responder responder, MCPConnection connection) {
         if (connectionManager.remove(connection.id())) {
-            MCPLogger.ROOT_LOGGER.debugf("Connection %s closed", connection.id());
+            ROOT_LOGGER.debugf("Connection %s closed", connection.id());
         } else {
             responder.sendError(message.get("id").toString(), JsonRPC.INTERNAL_ERROR,
                     "Unable to obtain the connection to be closed:" + connection.id());
@@ -223,14 +225,14 @@ public class MCPMessageHandler {
             context = new InitialContext();
             return (ExecutorService) context.lookup("java:jboss/ee/concurrency/executor/default");
         } catch (NamingException ex) {
-            MCPLogger.ROOT_LOGGER.warn("Managed executor service not available, using default executor service");
+            ROOT_LOGGER.managedExecutorServiceNotAvailable();
             return Executors.newCachedThreadPool();
         } finally {
             if (context != null) {
                 try {
                     context.close();
                 } catch (NamingException ex) {
-                    MCPLogger.ROOT_LOGGER.debug("Error closing initial context", ex);
+                    ROOT_LOGGER.debug("Error closing initial context", ex);
                 }
             }
         }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPServerSentConnectionCallBack.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPServerSentConnectionCallBack.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.extension.mcp.server;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.ConnectionManager.MCP_SESSION_ID_HEADER;
 import io.undertow.server.handlers.sse.ServerSentEventConnection;
 import io.undertow.server.handlers.sse.ServerSentEventConnectionCallback;
@@ -23,12 +24,12 @@ public class MCPServerSentConnectionCallBack implements ServerSentEventConnectio
     @Override
     public void connected(ServerSentEventConnection sseConnection, String lastEventId) {
         String id = connectionManager.id();
-        MCPLogger.ROOT_LOGGER.debug("Client connection initialized [%s]".formatted(id));
+        ROOT_LOGGER.debug("Client connection initialized [%s]".formatted(id));
         String endpointPath = endpoint + '/' + id;
         sseConnection.getResponseHeaders().add(MCP_SESSION_ID_HEADER, id);
         ServerSentEventResponder responder = new ServerSentEventResponder(sseConnection, id);
         connectionManager.add(responder);
-        MCPLogger.ROOT_LOGGER.debug("Sending endpoint [%s]".formatted(endpointPath));
+        ROOT_LOGGER.debug("Sending endpoint [%s]".formatted(endpointPath));
         responder.send("endpoint", endpointPath);
     }
 

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPStreamableConnectionCallBack.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPStreamableConnectionCallBack.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.extension.mcp.server;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.ConnectionManager.MCP_SESSION_ID_HEADER;
 import io.undertow.server.handlers.sse.ServerSentEventConnection;
 import io.undertow.server.handlers.sse.ServerSentEventConnectionCallback;
@@ -26,12 +27,12 @@ public class MCPStreamableConnectionCallBack implements ServerSentEventConnectio
     @Override
     public void connected(ServerSentEventConnection sseConnection, String lastEventId) {
         String id = sseConnection.getAttachment(SESSION_ID);
-        MCPLogger.ROOT_LOGGER.debug("Client connection initialized [%s]".formatted(id));
+        ROOT_LOGGER.debug("Client connection initialized [%s]".formatted(id));
         sseConnection.getResponseHeaders().add(MCP_SESSION_ID_HEADER, id);
         ServerSentEventResponder connection = new ServerSentEventResponder(sseConnection, id);
         connectionManager.add(connection);
         JsonObject content = sseConnection.getAttachment(JSON_PAYLOAD);
-        MCPLogger.ROOT_LOGGER.debug("Received message from client: %s".formatted(content));
+        ROOT_LOGGER.debug("Received message from client: %s".formatted(content));
         JsonRPC.validate(content, connection);
         StreamableHttpHandler.handler.handle(content, connection, connection);
     }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MessagesHttpHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MessagesHttpHandler.java
@@ -1,6 +1,7 @@
 package org.wildfly.extension.mcp.server;
 
 import static io.undertow.util.Headers.ALLOW;
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -42,7 +43,7 @@ public class MessagesHttpHandler implements HttpHandler {
         }
         String connectionId = exchange.getRequestPath().substring( exchange.getRequestPath().lastIndexOf('/') + 1);
         if (connectionId == null) {
-            MCPLogger.ROOT_LOGGER.warn("Connection id is missing: %s".formatted( exchange.getRequestPath()));
+            ROOT_LOGGER.connectionIdMissing(exchange.getRequestPath());
             exchange.setStatusCode(400);
             return;
         }
@@ -50,7 +51,7 @@ public class MessagesHttpHandler implements HttpHandler {
         exchange.startBlocking();
         JsonReader reader = Json.createReader(exchange.getInputStream());
         JsonObject content = reader.readObject();
-        MCPLogger.ROOT_LOGGER.debug("Received message from client: %s".formatted(content));
+        ROOT_LOGGER.debug("Received message from client: %s".formatted(content));
         JsonRPC.validate(content, connection);
         handler.handle(content, connection, connection);
     }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PendingRequestRegistry.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PendingRequestRegistry.java
@@ -11,6 +11,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.wildfly.extension.mcp.MCPLogger;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
+
 /**
  * Tracks pending server-initiated requests (e.g. {@code elicitation/create}) and routes
  * client responses back to the waiting {@link CompletableFuture}.
@@ -46,19 +48,19 @@ public class PendingRequestRegistry {
      */
     public void handleResponse(Object rawId, JsonObject message) {
         if (rawId == null) {
-            MCPLogger.ROOT_LOGGER.debugf("Client response has no id, discarding: %s", message);
+            ROOT_LOGGER.debugf("Client response has no id, discarding: %s", message);
             return;
         }
         long id;
         try {
             id = coerceId(rawId);
         } catch (NumberFormatException e) {
-            MCPLogger.ROOT_LOGGER.debugf("Client response id '%s' is not a long, discarding", rawId);
+            ROOT_LOGGER.debugf("Client response id '%s' is not a long, discarding", rawId);
             return;
         }
         CompletableFuture<JsonObject> future = pending.remove(id);
         if (future == null) {
-            MCPLogger.ROOT_LOGGER.debugf("No pending request for id %s, discarding client response", id);
+            ROOT_LOGGER.debugf("No pending request for id %s, discarding client response", id);
             return;
         }
         future.complete(message);

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PromptMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PromptMessageHandler.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.extension.mcp.server;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.JsonRPC.INTERNAL_ERROR;
 import static org.wildfly.extension.mcp.api.JsonRPC.INVALID_PARAMS;
 
@@ -36,7 +37,7 @@ import java.util.stream.StreamSupport;
 import org.wildfly.extension.mcp.api.Cursor;
 import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
-import org.wildfly.extension.mcp.injection.MCPLogger;
+import org.wildfly.extension.mcp.MCPLogger;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.extension.mcp.injection.tool.ArgumentMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
@@ -77,7 +78,7 @@ public class PromptMessageHandler {
         List<MCPFeatureMetadata> page = applyPage(sorted, cursorValue);
         String nextCursor = nextCursor(sorted, page);
 
-        MCPLogger.ROOT_LOGGER.debugf("List prompts [id: %s, cursor: %s, pageSize: %d]", id, cursorValue, pageSize);
+        ROOT_LOGGER.debugf("List prompts [id: %s, cursor: %s, pageSize: %d]", id, cursorValue, pageSize);
 
         JsonArrayBuilder prompts = Json.createArrayBuilder();
         for (MCPFeatureMetadata promptMetadata : page) {
@@ -139,7 +140,7 @@ public class PromptMessageHandler {
         }
         JsonObject params = paramsValue.asJsonObject();
         String promptName = params.getString("name");
-        MCPLogger.ROOT_LOGGER.debugf("Call prompt %s [id: %s]", promptName, id);
+        ROOT_LOGGER.debugf("Call prompt %s [id: %s]", promptName, id);
         Map<String, JsonValue> args = new HashMap<>();
         JsonObject arguments = params.getJsonObject("arguments");
         if (arguments != null) {
@@ -164,7 +165,7 @@ public class PromptMessageHandler {
                         Instance beanInstance = CDI.current().select(clazz, MCPPrompt.MCPPromptLiteral.INSTANCE);
                         Object result = null;
                         if (beanInstance.isResolvable()) {
-                            MCPLogger.ROOT_LOGGER.debugf("We have found the Singleton instance of the prompt %s", promptName);
+                            ROOT_LOGGER.debugf("We have found the Singleton instance of the prompt %s", promptName);
                             try {
                                 if (args.isEmpty()) {
                                     result = registry.getPromptInvoker(promptName).invoke(beanInstance.get());
@@ -174,11 +175,11 @@ public class PromptMessageHandler {
                                     result = registry.getPromptInvoker(promptName).invokeWithArguments(preparedArguments);
                                 }
                             } catch (Throwable ex) {
-                                MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking tool %s", promptName);
+                                ROOT_LOGGER.errorInvokingPrompt(ex, promptName);
                                 responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                             }
                         } else {
-                            MCPLogger.ROOT_LOGGER.warnf("We have NOT found the Singleton instance of the prompt %s", promptName);
+                            ROOT_LOGGER.debugf("Singleton instance not found for prompt %s, using reflection", promptName);
                             Method method = clazz.getMethod(methodMetadata.name(), methodMetadata.argumentTypes());
                             if (Modifier.isStatic(method.getModifiers())) {
                                 result = method.invoke(null, prepareArguments(metadata, args, mapper));
@@ -215,10 +216,10 @@ public class PromptMessageHandler {
                         builder.add("messages", messagesArray);
                         responder.sendResult(id, builder);
                     } catch (MCPException e) {
-                        MCPLogger.ROOT_LOGGER.error(e);
+                        ROOT_LOGGER.errorProcessingRequest(e);
                         responder.sendError(id, e.getJsonRpcError(), e.getMessage());
                     } catch (IOException | IllegalAccessException | InvocationTargetException | NoSuchMethodException | SecurityException | ClassNotFoundException | InstantiationException | IllegalArgumentException ex) {
-                        MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking prompt %s", promptName);
+                        ROOT_LOGGER.errorInvokingPrompt(ex, promptName);
                         responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                     }
                 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceMessageHandler.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.extension.mcp.server;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.JsonRPC.INTERNAL_ERROR;
 import static org.wildfly.extension.mcp.api.JsonRPC.INVALID_PARAMS;
 
@@ -38,7 +39,7 @@ import org.wildfly.extension.mcp.api.Cursor;
 import org.wildfly.extension.mcp.api.ContentMapper;
 import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
-import org.wildfly.extension.mcp.injection.MCPLogger;
+import org.wildfly.extension.mcp.MCPLogger;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPResource;
@@ -80,7 +81,7 @@ public class ResourceMessageHandler {
         List<MCPFeatureMetadata> page = applyPage(sorted, cursorValue);
         String nextCursor = nextCursor(sorted, page);
 
-        MCPLogger.ROOT_LOGGER.debugf("List resources [id: %s, cursor: %s, pageSize: %d]", id, cursorValue, pageSize);
+        ROOT_LOGGER.debugf("List resources [id: %s, cursor: %s, pageSize: %d]", id, cursorValue, pageSize);
 
         JsonArrayBuilder resources = Json.createArrayBuilder();
         for (MCPFeatureMetadata resourceMetadata : page) {
@@ -137,7 +138,7 @@ public class ResourceMessageHandler {
             responder.sendError(id, INVALID_PARAMS, "Resource URI not defined");
             return;
         }
-        MCPLogger.ROOT_LOGGER.debugf("Subscribe to resource %s [id: %s]", resourceUri, id);
+        ROOT_LOGGER.debugf("Subscribe to resource %s [id: %s]", resourceUri, id);
         responder.sendResult(id, Json.createObjectBuilder());
     }
 
@@ -153,7 +154,7 @@ public class ResourceMessageHandler {
             responder.sendError(id, INVALID_PARAMS, "Resource URI not defined");
             return;
         }
-        MCPLogger.ROOT_LOGGER.debugf("Unsubscribe from resource %s [id: %s]", resourceUri, id);
+        ROOT_LOGGER.debugf("Unsubscribe from resource %s [id: %s]", resourceUri, id);
         responder.sendResult(id, Json.createObjectBuilder());
     }
 
@@ -166,7 +167,7 @@ public class ResourceMessageHandler {
         }
         JsonObject params = paramsValue.asJsonObject();
         String resourceUri = params.getString("uri");
-        MCPLogger.ROOT_LOGGER.debugf("Call resource %s [id: %s]", resourceUri, id);
+        ROOT_LOGGER.debugf("Call resource %s [id: %s]", resourceUri, id);
         Map<String, JsonValue> args = new HashMap<>();
         JsonObject arguments = params.getJsonObject("arguments");
         if (arguments != null) {
@@ -191,7 +192,7 @@ public class ResourceMessageHandler {
                         Instance beanInstance = CDI.current().select(clazz, MCPResource.MCPResourceLiteral.INSTANCE);
                         Object result = null;
                         if (beanInstance.isResolvable()) {
-                            MCPLogger.ROOT_LOGGER.infof("We have found the Singleton instance of the resource %s", resourceUri);
+                            ROOT_LOGGER.debugf("Singleton instance found for resource %s", resourceUri);
                             try {
                                 if (args.isEmpty()) {
                                     result = registry.getResourceInvoker(resourceUri).invoke(beanInstance.get());
@@ -201,11 +202,11 @@ public class ResourceMessageHandler {
                                     result = registry.getResourceInvoker(resourceUri).invokeWithArguments(preparedArguments);
                                 }
                             } catch (Throwable ex) {
-                                MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking resource %s", resourceUri);
+                                ROOT_LOGGER.errorInvokingResource(ex, resourceUri);
                                 responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                             }
                         } else {
-                            MCPLogger.ROOT_LOGGER.warnf("We have NOT found the Singleton instance of the resource %s", resourceUri);
+                            ROOT_LOGGER.debugf("Singleton instance not found for resource %s, using reflection", resourceUri);
                             Method method = clazz.getMethod(methodMetadata.name(), methodMetadata.argumentTypes());
                             if (Modifier.isStatic(method.getModifiers())) {
                                 result = method.invoke(null, prepareArguments(metadata, args, mapper));
@@ -235,10 +236,10 @@ public class ResourceMessageHandler {
                         builder.add("contents", jsonContent);
                         responder.sendResult(id, builder);
                     } catch (MCPException e) {
-                        MCPLogger.ROOT_LOGGER.error(e);
+                        ROOT_LOGGER.errorProcessingRequest(e);
                         responder.sendError(id, e.getJsonRpcError(), e.getMessage());
                     } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | SecurityException | ClassNotFoundException | InstantiationException | IllegalArgumentException ex) {
-                        MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking resource %s", resourceUri);
+                        ROOT_LOGGER.errorInvokingResource(ex, resourceUri);
                         responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                     }
                 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceTemplateMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceTemplateMessageHandler.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.extension.mcp.server;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.JsonRPC.INTERNAL_ERROR;
 import static org.wildfly.extension.mcp.api.JsonRPC.INVALID_PARAMS;
 
@@ -37,7 +38,7 @@ import org.wildfly.extension.mcp.api.Cursor;
 import org.wildfly.extension.mcp.api.ContentMapper;
 import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
-import org.wildfly.extension.mcp.injection.MCPLogger;
+import org.wildfly.extension.mcp.MCPLogger;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.extension.mcp.injection.tool.ArgumentMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
@@ -77,7 +78,7 @@ public class ResourceTemplateMessageHandler {
         List<MCPFeatureMetadata> page = applyPage(sorted, cursorValue);
         String nextCursor = nextCursor(sorted, page);
 
-        MCPLogger.ROOT_LOGGER.debugf("List resource templates [id: %s, cursor: %s, pageSize: %d]", id, cursorValue, pageSize);
+        ROOT_LOGGER.debugf("List resource templates [id: %s, cursor: %s, pageSize: %d]", id, cursorValue, pageSize);
 
         JsonArrayBuilder templates = Json.createArrayBuilder();
         for (MCPFeatureMetadata metadata : page) {
@@ -131,7 +132,7 @@ public class ResourceTemplateMessageHandler {
         }
         JsonObject params = paramsValue.asJsonObject();
         String resourceUri = params.getString("uri");
-        MCPLogger.ROOT_LOGGER.debugf("Read resource template %s [id: %s]", resourceUri, id);
+        ROOT_LOGGER.debugf("Read resource template %s [id: %s]", resourceUri, id);
 
         final MCPFeatureMetadata metadata = registry.findResourceTemplateByUri(resourceUri);
         if (metadata == null) {
@@ -152,7 +153,7 @@ public class ResourceTemplateMessageHandler {
                         Object result = null;
                         MethodHandle invoker = registry.findResourceTemplateInvokerByUri(resourceUri);
                         if (beanInstance.isResolvable()) {
-                            MCPLogger.ROOT_LOGGER.debugf("We have found the Singleton instance of the resource template %s", resourceUri);
+                            ROOT_LOGGER.debugf("We have found the Singleton instance of the resource template %s", resourceUri);
                             try {
                                 if (args.isEmpty()) {
                                     result = invoker.invoke(beanInstance.get());
@@ -162,11 +163,11 @@ public class ResourceTemplateMessageHandler {
                                     result = invoker.invokeWithArguments(preparedArguments);
                                 }
                             } catch (Throwable ex) {
-                                MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking resource template %s", resourceUri);
+                                ROOT_LOGGER.errorInvokingResourceTemplate(ex, resourceUri);
                                 responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                             }
                         } else {
-                            MCPLogger.ROOT_LOGGER.warnf("We have NOT found the Singleton instance of the resource template %s", resourceUri);
+                            ROOT_LOGGER.debugf("Singleton instance not found for resource template %s, using reflection", resourceUri);
                             Method method = clazz.getMethod(methodMetadata.name(), methodMetadata.argumentTypes());
                             if (Modifier.isStatic(method.getModifiers())) {
                                 result = method.invoke(null, prepareArguments(metadata, args, mapper));
@@ -196,10 +197,10 @@ public class ResourceTemplateMessageHandler {
                         builder.add("contents", jsonContent);
                         responder.sendResult(id, builder);
                     } catch (MCPException e) {
-                        MCPLogger.ROOT_LOGGER.error(e);
+                        ROOT_LOGGER.errorProcessingRequest(e);
                         responder.sendError(id, e.getJsonRpcError(), e.getMessage());
                     } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | SecurityException | ClassNotFoundException | InstantiationException | IllegalArgumentException ex) {
-                        MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking resource template %s", resourceUri);
+                        ROOT_LOGGER.errorInvokingResourceTemplate(ex, resourceUri);
                         responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                     }
                 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ServerSentEventResponder.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ServerSentEventResponder.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.extension.mcp.server;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.ConnectionManager.MCP_SESSION_ID_HEADER;
 import io.undertow.server.handlers.sse.ServerSentEventConnection;
 import jakarta.json.Json;
@@ -70,23 +71,22 @@ public class ServerSentEventResponder implements Responder, MCPConnection {
             jsonWriter.writeObject(message);
             send("message", writer.toString());
         } catch (IOException ex) {
-            MCPLogger.ROOT_LOGGER.error("Failure sending message", ex);
-            ex.printStackTrace();
+            ROOT_LOGGER.failureSendingMessage(ex);
         }
     }
 
     public void send(String name, String message) {
-        MCPLogger.ROOT_LOGGER.debugf("Sending message of type %s with content %s", name, message);
+        ROOT_LOGGER.debugf("Sending message of type %s with content %s", name, message);
         connection.getResponseHeaders().add(MCP_SESSION_ID_HEADER, id);
         connection.send(message, name,""+ lastEventId(), new ServerSentEventConnection.EventCallback() {
             @Override
             public void done(ServerSentEventConnection connection, String data, String event, String id) {
-                MCPLogger.ROOT_LOGGER.warnf("Message sent: %s", data);
+                ROOT_LOGGER.debugf("Message sent: %s", data);
             }
 
             @Override
             public void failed(ServerSentEventConnection connection, String data, String event, String id, IOException e) {
-                MCPLogger.ROOT_LOGGER.warn("Failed to send event to client: %s".formatted(data));
+                ROOT_LOGGER.failedToSendEvent(data);
                 close();
             }
         });
@@ -97,7 +97,7 @@ public class ServerSentEventResponder implements Responder, MCPConnection {
         try {
             this.connection.close();
         } catch (IOException ex) {
-            MCPLogger.ROOT_LOGGER.debug("Error closing the SSEConnection", ex);
+            ROOT_LOGGER.debug("Error closing the SSEConnection", ex);
         }
     }
 
@@ -106,7 +106,7 @@ public class ServerSentEventResponder implements Responder, MCPConnection {
         if (this.future != null && !this.future.isDone()) {
             Future task = this.future;
             this.future = null;
-            MCPLogger.ROOT_LOGGER.warn("Task not finished");
+            ROOT_LOGGER.debug("Task not finished");
             task.cancel(true);
         }
         this.future = future;
@@ -117,7 +117,7 @@ public class ServerSentEventResponder implements Responder, MCPConnection {
         if (this.future != null && !this.future.isDone()) {
             Future task = this.future;
             this.future = null;
-            MCPLogger.ROOT_LOGGER.warn("Task cancelled");
+            ROOT_LOGGER.debug("Task cancelled");
             task.cancel(true);
         }
 

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/StreamableHttpHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/StreamableHttpHandler.java
@@ -5,6 +5,7 @@ import static io.undertow.util.Headers.CACHE_CONTROL;
 import static io.undertow.util.Headers.CONTENT_TYPE;
 import static io.undertow.util.HttpString.tryFromString;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.ConnectionManager.MCP_PROTOCOL_VERSION_HEADER;
 import static org.wildfly.extension.mcp.api.ConnectionManager.MCP_SESSION_ID_HEADER;
 import static org.wildfly.extension.mcp.server.MCPMessageHandler.PROTOCOL_VERSION;
@@ -51,14 +52,14 @@ public class StreamableHttpHandler implements HttpHandler {
             return;
         }
         if (!Methods.POST.equals(exchange.getRequestMethod())) {
-            MCPLogger.ROOT_LOGGER.invalidHttpMethod(exchange.getRequestMethod().toString());
+            ROOT_LOGGER.invalidHttpMethod(exchange.getRequestMethod().toString());
             exchange.setStatusCode(405).getResponseHeaders().add(ALLOW, Methods.POST_STRING);
             exchange.endExchange();
             return;
         }
         HeaderValues accepts = exchange.getRequestHeaders().get(Headers.ACCEPT);
-        if (!isValideAcceptHeader(accepts)) {
-            MCPLogger.ROOT_LOGGER.invalidAcceptHeaders(Arrays.toString(accepts.toArray()));
+        if (!isValidAcceptHeader(accepts)) {
+            ROOT_LOGGER.invalidAcceptHeaders(Arrays.toString(accepts.toArray()));
             exchange.setStatusCode(400);
             exchange.endExchange();
             return;
@@ -71,7 +72,7 @@ public class StreamableHttpHandler implements HttpHandler {
         exchange.startBlocking();
         JsonReader reader = Json.createReader(exchange.getInputStream());
         JsonObject content = reader.readObject();
-        MCPLogger.ROOT_LOGGER.debug("Received message from client: %s".formatted(content));
+        ROOT_LOGGER.debug("Received message from client: %s".formatted(content));
         String connectionId = exchange.getRequestHeaders().getFirst(MCP_SESSION_ID_HEADER);
         if (connectionId == null) {
             connectionId = connectionManager.id();
@@ -103,7 +104,7 @@ public class StreamableHttpHandler implements HttpHandler {
         handler.handle(content, connection, connection);
     }
 
-    private boolean isValideAcceptHeader(HeaderValues accepts) {
+    private boolean isValidAcceptHeader(HeaderValues accepts) {
         for (String accept : accepts) {
             if (accept.contains("application/json") && accept.contains("text/event-stream")) {
                 return true;

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.extension.mcp.server;
 
+import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.JsonRPC.INTERNAL_ERROR;
 import static org.wildfly.extension.mcp.api.JsonRPC.INVALID_PARAMS;
 
@@ -48,7 +49,7 @@ import org.wildfly.extension.mcp.api.ContentMapper;
 import org.wildfly.extension.mcp.api.JsonRPC;
 import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
-import org.wildfly.extension.mcp.injection.MCPLogger;
+import org.wildfly.extension.mcp.MCPLogger;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.extension.mcp.injection.tool.ArgumentMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
@@ -92,7 +93,7 @@ public class ToolMessageHandler {
         List<MCPFeatureMetadata> page = applyPage(sorted, cursorValue);
         String nextCursor = nextCursor(sorted, page);
 
-        MCPLogger.ROOT_LOGGER.debugf("List tools [id: %s, cursor: %s, pageSize: %d]", id, cursorValue, pageSize);
+        ROOT_LOGGER.debugf("List tools [id: %s, cursor: %s, pageSize: %d]", id, cursorValue, pageSize);
 
         JsonArrayBuilder tools = Json.createArrayBuilder();
         for (MCPFeatureMetadata toolMetadata : page) {
@@ -173,7 +174,7 @@ public class ToolMessageHandler {
         }
         JsonObject params = paramsValue.asJsonObject();
         String toolName = params.getString("name");
-        MCPLogger.ROOT_LOGGER.debugf("Call tool %s [id: %s]", toolName, id);
+        ROOT_LOGGER.debugf("Call tool %s [id: %s]", toolName, id);
         Map<String, JsonValue> args = new HashMap<>();
         JsonObject arguments = params.getJsonObject("arguments");
         if (arguments != null) {
@@ -199,7 +200,7 @@ public class ToolMessageHandler {
                         Object result = null;
                         Object[] builtArgs = buildArguments(metadata, args, mapper, connection, responder);
                         if (beanInstance.isResolvable()) {
-                            MCPLogger.ROOT_LOGGER.debugf("We have found the Singleton instance of the tool %s", toolName);
+                            ROOT_LOGGER.debugf("The Singleton instance of the tool %s has been found", toolName);
                             try {
                                 if (builtArgs.length == 0) {
                                     result = registry.getToolInvoker(toolName).invoke(beanInstance.get());
@@ -209,11 +210,11 @@ public class ToolMessageHandler {
                                     result = registry.getToolInvoker(toolName).invokeWithArguments(preparedArguments);
                                 }
                             } catch (Throwable ex) {
-                                MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking tool %s", toolName);
+                                ROOT_LOGGER.errorInvokingTool(ex, toolName);
                                 responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                             }
                         } else {
-                            MCPLogger.ROOT_LOGGER.warnf("We have NOT found the Singleton instance of the tool %s", toolName);
+                            ROOT_LOGGER.debugf("The Singleton instance for tool %s has not been found, using reflection instead", toolName);
                             Method method = clazz.getMethod(methodMetadata.name(), methodMetadata.argumentTypes());
                             if (Modifier.isStatic(method.getModifiers())) {
                                 result = method.invoke(null, builtArgs);
@@ -244,10 +245,10 @@ public class ToolMessageHandler {
                         builder.add("content", contentArray);
                         responder.sendResult(id, builder);
                     } catch (MCPException e) {
-                        MCPLogger.ROOT_LOGGER.error(e);
+                        ROOT_LOGGER.errorProcessingRequest(e);
                         responder.sendError(id, e.getJsonRpcError(), e.getMessage());
                     } catch (IOException | IllegalAccessException | InvocationTargetException | NoSuchMethodException | SecurityException | ClassNotFoundException | InstantiationException | IllegalArgumentException ex) {
-                        MCPLogger.ROOT_LOGGER.errorf(ex, "Error invoking tool %s", toolName);
+                        ROOT_LOGGER.errorInvokingTool(ex, toolName);
                         responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                     }
                 }


### PR DESCRIPTION
Replace inline string logging at INFO level and above with properly defined @LogMessage/@Message methods in MCPLogger interfaces. Demote operational messages (ping, client init, singleton lookup, CDI discovery) to DEBUG level. Switch handler files from injection MCPLogger to subsystem MCPLogger.

This fixes #264.