### PR TITLE
chore: mark all attributes and operations as experimental

### DIFF
--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/AIAttributeDefinitions.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/AIAttributeDefinitions.java
@@ -15,6 +15,7 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -27,84 +28,107 @@ public class AIAttributeDefinitions {
     public static final SimpleAttributeDefinition API_KEY = new SimpleAttributeDefinitionBuilder("api-key", ModelType.STRING, false)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition BASE_URL = new SimpleAttributeDefinitionBuilder("base-url", ModelType.STRING, false)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition BOLT_URL = new SimpleAttributeDefinitionBuilder("bolt-url", ModelType.STRING, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition CONNECT_TIMEOUT = new SimpleAttributeDefinitionBuilder("connect-timeout", ModelType.LONG, true)
             .setAllowExpression(true)
             .setDefaultValue(ModelNode.ZERO)
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = CredentialReference.getAttributeBuilder(true, true)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition EXECUTOR_SERVICE = new SimpleAttributeDefinitionBuilder("executor-service", ModelType.STRING, false)
             .setCapabilityReference(MANAGED_EXECUTOR_CAPABILITY_NAME)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition FREQUENCY_PENALTY = new SimpleAttributeDefinitionBuilder("frequency-penalty", ModelType.DOUBLE, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition LOG_REQUESTS = SimpleAttributeDefinitionBuilder.create("log-requests", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition LOG_REQUESTS_RESPONSES = SimpleAttributeDefinitionBuilder.create("log-requests-responses", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition LOG_RESPONSES = SimpleAttributeDefinitionBuilder.create("log-responses", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition MAX_RETRIES = SimpleAttributeDefinitionBuilder.create("max-retries", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition MAX_TOKEN = new SimpleAttributeDefinitionBuilder("max-token", ModelType.INT, true)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(1000))
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition MODEL_NAME = new SimpleAttributeDefinitionBuilder("model-name", ModelType.STRING, false)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition PRESENCE_PENALTY = new SimpleAttributeDefinitionBuilder("presence-penalty", ModelType.DOUBLE, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition RESPONSE_FORMAT = new SimpleAttributeDefinitionBuilder("response-format", ModelType.STRING, true)
             .setValidator(EnumValidator.create(ResponseFormat.class))
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition SEED = new SimpleAttributeDefinitionBuilder("seed", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition SSL_ENABLED = SimpleAttributeDefinitionBuilder.create("ssl-enabled", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
             .setDefaultValue(ModelNode.FALSE)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final StringListAttributeDefinition STOP_SEQUENCES = StringListAttributeDefinition.Builder.of("stop-sequences")
             .setRequired(false)
             .setMinSize(0)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition STREAMING = new SimpleAttributeDefinitionBuilder("streaming", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
             .setDefaultValue(ModelNode.FALSE)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition TEMPERATURE = new SimpleAttributeDefinitionBuilder("temperature", ModelType.DOUBLE, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition TOP_P = new SimpleAttributeDefinitionBuilder("top-p", ModelType.DOUBLE, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition USER_MESSAGE = new SimpleAttributeDefinitionBuilder("user-message", ModelType.STRING, false)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition USERNAME = new SimpleAttributeDefinitionBuilder("username", ModelType.STRING, false)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public enum ResponseFormat {

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/AISubsystemSchema.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/AISubsystemSchema.java
@@ -15,6 +15,7 @@ import org.jboss.as.controller.persistence.xml.SubsystemResourceRegistrationXMLE
 import org.jboss.as.controller.persistence.xml.SubsystemResourceXMLSchema;
 import org.jboss.as.controller.xml.VersionedNamespace;
 import org.jboss.as.controller.xml.XMLCardinality;
+import org.jboss.as.version.Stability;
 import org.jboss.staxmapper.IntVersion;
 import org.wildfly.extension.ai.chat.GeminiChatLanguageModelProviderRegistrar;
 import org.wildfly.extension.ai.chat.GithubModelChatLanguageModelProviderRegistrar;
@@ -46,7 +47,7 @@ enum AISubsystemSchema implements SubsystemResourceXMLSchema<AISubsystemSchema> 
     private final VersionedNamespace<IntVersion, AISubsystemSchema> namespace;
 
     AISubsystemSchema(int major, int minor) {
-        this.namespace = SubsystemSchema.createLegacySubsystemURN(AISubsystemRegistrar.NAME, new IntVersion(major, minor));
+        this.namespace = SubsystemSchema.createLegacySubsystemURN(AISubsystemRegistrar.NAME, Stability.EXPERIMENTAL, new IntVersion(major, minor));
     }
 
     @Override

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/ChatModelConnectionCheckerOperationHandler.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/ChatModelConnectionCheckerOperationHandler.java
@@ -14,6 +14,7 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.ai.AILogger;
 import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
@@ -34,6 +35,7 @@ public class ChatModelConnectionCheckerOperationHandler implements OperationStep
                 .setReplyType(STRING)
                 .setRuntimeOnly()
                 .setReadOnly()
+                .setStability(Stability.EXPERIMENTAL)
                 .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
                 .build(), new ChatModelConnectionCheckerOperationHandler(registry));
     }

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/GeminiChatLanguageModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/GeminiChatLanguageModelProviderRegistrar.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 import org.wildfly.service.capture.ValueExecutorRegistry;
@@ -46,53 +47,68 @@ public class GeminiChatLanguageModelProviderRegistrar implements ChildResourceDe
     private static final String[] THRESHOLDS = new String[]{"HARM_BLOCK_THRESHOLD_UNSPECIFIED", "BLOCK_LOW_AND_ABOVE", "BLOCK_MEDIUM_AND_ABOVE", "BLOCK_ONLY_HIGH", "BLOCK_NONE"};
     public static final SimpleAttributeDefinition ALLOWED_CODE_EXECUTION = new SimpleAttributeDefinitionBuilder("allowed-code-execution", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition CIVIC_INTEGRITY = new SimpleAttributeDefinitionBuilder("civic-integrity", ModelType.STRING, true)
             .setAllowedValues(THRESHOLDS)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition DANGEROUS_CONTENT = new SimpleAttributeDefinitionBuilder("dangerous-content", ModelType.STRING, true)
             .setAllowedValues(THRESHOLDS)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition ENABLE_ENHANCED_CIVIC_ANSWERS = new SimpleAttributeDefinitionBuilder("enable-enhanced-civic-answers", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition HARASSMENT = new SimpleAttributeDefinitionBuilder("harassment", ModelType.STRING, true)
             .setAllowedValues(THRESHOLDS)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition HATE_SPEECH = new SimpleAttributeDefinitionBuilder("hate-speech", ModelType.STRING, true)
             .setAllowedValues(THRESHOLDS)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition INCLUDE_CODE_EXECUTION_OUTPUT = new SimpleAttributeDefinitionBuilder("include-code-execution-output", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition INCLUDE_THOUGHTS = new SimpleAttributeDefinitionBuilder("include-thoughts", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition LOG_PROBS = new SimpleAttributeDefinitionBuilder("log-probs", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition MAX_OUTPUT_TOKEN = new SimpleAttributeDefinitionBuilder("max-output-token", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition RESPONSE_LOG_PROBS = new SimpleAttributeDefinitionBuilder("response-log-probs", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition RETURN_THINKING = new SimpleAttributeDefinitionBuilder("return-thinking", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition SEXUALLY_EXPLICIT = new SimpleAttributeDefinitionBuilder("sexually-explicit", ModelType.STRING, true)
             .setAllowedValues(THRESHOLDS)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition THINKING_BUDGET = new SimpleAttributeDefinitionBuilder("thinking-budget", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition TOP_K = new SimpleAttributeDefinitionBuilder("top-k", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
 

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/GithubModelChatLanguageModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/GithubModelChatLanguageModelProviderRegistrar.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 
 import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
@@ -49,19 +50,24 @@ public class GithubModelChatLanguageModelProviderRegistrar implements ChildResou
             .setAllowExpression(true)
             .setAttributeParser(new AttributeParsers.PropertiesParser(null, "header", false))
             .setAttributeMarshaller(new AttributeMarshallers.PropertiesAttributeMarshaller(null, "header", false))
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition ENDPOINT = SimpleAttributeDefinitionBuilder.create("endpoint", ModelType.STRING, false)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition SEED = new SimpleAttributeDefinitionBuilder("seed", ModelType.LONG, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition SERVICE_VERSION = new SimpleAttributeDefinitionBuilder("service-version", ModelType.STRING, true)
             .setAllowedValues("2024-05-01-preview", "2024-05-01-preview")
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition USER_AGENT_SUFFIX = new SimpleAttributeDefinitionBuilder("user-agent-suffix", ModelType.STRING, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(API_KEY, CONNECT_TIMEOUT,CUSTOM_HEADERS,

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/MistralAIChatLanguageModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/MistralAIChatLanguageModelProviderRegistrar.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.ai.injection.chat.WildFlyChatModelConfig;
 import org.wildfly.service.capture.ValueExecutorRegistry;
@@ -47,9 +48,11 @@ public class MistralAIChatLanguageModelProviderRegistrar implements ChildResourc
 
     public static final SimpleAttributeDefinition RANDOM_SEED = new SimpleAttributeDefinitionBuilder("random-seed", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition SAFE_PROMPT = SimpleAttributeDefinitionBuilder.create("safe-prompt", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(API_KEY, BASE_URL, CONNECT_TIMEOUT,

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/OllamaChatLanguageModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/OllamaChatLanguageModelProviderRegistrar.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 
 import static org.wildfly.extension.ai.AIAttributeDefinitions.RESPONSE_FORMAT;
@@ -45,12 +46,15 @@ public class OllamaChatLanguageModelProviderRegistrar implements ChildResourceDe
 
     public static final SimpleAttributeDefinition NUM_PREDICT = new SimpleAttributeDefinitionBuilder("num-predict", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition REPEAT_PENALTY = new SimpleAttributeDefinitionBuilder("repeat-penalty", ModelType.DOUBLE, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition TOP_K = new SimpleAttributeDefinitionBuilder("top-k", ModelType.INT, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(BASE_URL, CONNECT_TIMEOUT,

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/OpenAIChatLanguageModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/chat/OpenAIChatLanguageModelProviderRegistrar.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 
 import static org.wildfly.extension.ai.AIAttributeDefinitions.RESPONSE_FORMAT;
@@ -46,6 +47,7 @@ import org.wildfly.subsystem.resource.operation.ResourceOperationRuntimeHandler;
 public class OpenAIChatLanguageModelProviderRegistrar implements ChildResourceDefinitionRegistrar {
     public static final SimpleAttributeDefinition ORGANIZATION_ID = new SimpleAttributeDefinitionBuilder("organization-id", ModelType.STRING, true)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(API_KEY, BASE_URL, CONNECT_TIMEOUT,
             EXECUTOR_SERVICE, FREQUENCY_PENALTY, LOG_REQUESTS, LOG_RESPONSES, MAX_TOKEN, MODEL_NAME, ORGANIZATION_ID,

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/model/InMemoryEmbeddingModelProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/model/InMemoryEmbeddingModelProviderRegistrar.java
@@ -18,6 +18,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -30,9 +31,11 @@ public class InMemoryEmbeddingModelProviderRegistrar implements ChildResourceDef
     public static final SimpleAttributeDefinition EMBEDDING_MODULE = new SimpleAttributeDefinitionBuilder(MODULE, ModelType.STRING, false)
             .setAllowExpression(true)
             .setValidator(new ModuleIdentifierValidator(false, true))
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition EMBEDDING_MODEL_CLASS = new SimpleAttributeDefinitionBuilder("embedding-class", ModelType.STRING, false)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(EMBEDDING_MODULE, EMBEDDING_MODEL_CLASS);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/store/ChromaEmbeddingStoreProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/store/ChromaEmbeddingStoreProviderRegistrar.java
@@ -22,6 +22,7 @@ import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -35,20 +36,24 @@ public class ChromaEmbeddingStoreProviderRegistrar implements ChildResourceDefin
     protected static final SimpleAttributeDefinition API_VERSION = new SimpleAttributeDefinitionBuilder("api-version", ModelType.STRING, false)
             .setValidator(EnumValidator.create(ChromaAPIVersion.class))
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     protected static final SimpleAttributeDefinition COLLECTION_NAME
             = new SimpleAttributeDefinitionBuilder("collection-name", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     protected static final SimpleAttributeDefinition DATABASE_NAME
             = new SimpleAttributeDefinitionBuilder("database-name", ModelType.STRING, true)
                     .setDefaultValue(new ModelNode("default"))
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     protected static final SimpleAttributeDefinition TENANT_NAME
             = new SimpleAttributeDefinitionBuilder("tenant-name", ModelType.STRING, true)
                     .setDefaultValue(new ModelNode("default"))
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
 
     private final ResourceDescriptor descriptor;

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/store/InMemoryEmbeddingStoreProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/store/InMemoryEmbeddingStoreProviderRegistrar.java
@@ -20,6 +20,7 @@ import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.ResolvePathHandler;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -36,12 +37,14 @@ public class InMemoryEmbeddingStoreProviderRegistrar implements ChildResourceDef
                     .setAllowExpression(true)
                     .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
                     .addArbitraryDescriptor(FILESYSTEM_PATH, ModelNode.TRUE)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     protected static final SimpleAttributeDefinition STORE_RELATIVE_TO
             = new SimpleAttributeDefinitionBuilder("relative-to", ModelType.STRING, true)
                     .setXmlName("relative-to")
                     .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
                     .setCapabilityReference(PathManager.PATH_SERVICE_DESCRIPTOR.getName())
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(STORE_PATH, STORE_RELATIVE_TO);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/store/Neo4jEmbeddingStoreProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/store/Neo4jEmbeddingStoreProviderRegistrar.java
@@ -21,6 +21,7 @@ import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -33,39 +34,48 @@ public class Neo4jEmbeddingStoreProviderRegistrar implements ChildResourceDefini
     public static final SimpleAttributeDefinition DATABASE_NAME
             = new SimpleAttributeDefinitionBuilder("database-name", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     public static final SimpleAttributeDefinition DIMENSION
             = new SimpleAttributeDefinitionBuilder("dimension", ModelType.INT, false)
                     .setAllowExpression(true)
                     .setValidator(IntRangeValidator.POSITIVE)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     public static final SimpleAttributeDefinition EMBEDDING_PROPERTY
             = new SimpleAttributeDefinitionBuilder("embedding-property", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     public static final SimpleAttributeDefinition ID_PROPERTY
             = new SimpleAttributeDefinitionBuilder("id-property", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     public static final SimpleAttributeDefinition INDEX_NAME
             = new SimpleAttributeDefinitionBuilder("index-name", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     public static final SimpleAttributeDefinition LABEL
             = new SimpleAttributeDefinitionBuilder("label", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     public static final SimpleAttributeDefinition METADATA_PREFIX
             = new SimpleAttributeDefinitionBuilder("metadata-prefix", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     public static final SimpleAttributeDefinition RETRIEVAL_QUERY
             = new SimpleAttributeDefinitionBuilder("retrieval-query", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     public static final SimpleAttributeDefinition TEXT_PROPERTY
             = new SimpleAttributeDefinitionBuilder("text-property", ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(BOLT_URL, CREDENTIAL_REFERENCE, DATABASE_NAME,

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/store/WeaviateEmbeddingStoreProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/embedding/store/WeaviateEmbeddingStoreProviderRegistrar.java
@@ -22,6 +22,7 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -35,28 +36,33 @@ public class WeaviateEmbeddingStoreProviderRegistrar implements ChildResourceDef
     public static final SimpleAttributeDefinition AVOID_DUPS = SimpleAttributeDefinitionBuilder.create("avoid-dups", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition CONSISTENCY_LEVEL = SimpleAttributeDefinitionBuilder.create("consistency-level", ModelType.STRING, true)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode("ALL"))
             .setAllowedValues("ONE", "QUORUM", "ALL")
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition OBJECT_CLASS = SimpleAttributeDefinitionBuilder.create("object-class", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition STORE_BINDING = SimpleAttributeDefinitionBuilder.create(SOCKET_BINDING, ModelType.STRING, false)
             .setAllowExpression(true)
             .setCapabilityReference(OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final StringListAttributeDefinition METADATA = StringListAttributeDefinition.Builder.of("metadata")
             .setRequired(false)
             .setMinSize(0)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(AVOID_DUPS, CONSISTENCY_LEVEL, METADATA, OBJECT_CLASS, SSL_ENABLED, STORE_BINDING);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientSseProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientSseProviderRegistrar.java
@@ -23,6 +23,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -37,10 +38,12 @@ public class McpClientSseProviderRegistrar implements ChildResourceDefinitionReg
             .setCapabilityReference(OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition SSE_PATH = SimpleAttributeDefinitionBuilder.create("sse-path", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(CONNECT_TIMEOUT, LOG_REQUESTS, LOG_RESPONSES, SSE_PATH, SSL_ENABLED, SSE_SOCKET_BINDING);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientStdioProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientStdioProviderRegistrar.java
@@ -17,6 +17,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -29,10 +30,12 @@ public class McpClientStdioProviderRegistrar implements ChildResourceDefinitionR
     public static final StringListAttributeDefinition COMMAND_ARGS = new StringListAttributeDefinition.Builder("args")
             .setAllowExpression(true)
             .setMinSize(0)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition COMMAND = SimpleAttributeDefinitionBuilder.create("cmd", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(COMMAND, COMMAND_ARGS);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientStreamableProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientStreamableProviderRegistrar.java
@@ -23,6 +23,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -37,10 +38,12 @@ public class McpClientStreamableProviderRegistrar implements ChildResourceDefini
             .setCapabilityReference(OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition STREAM_PATH = SimpleAttributeDefinitionBuilder.create("stream-path", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(CONNECT_TIMEOUT, LOG_REQUESTS, LOG_RESPONSES, STREAM_PATH, SSL_ENABLED, STREAM_SOCKET_BINDING);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpToolProviderProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpToolProviderProviderRegistrar.java
@@ -20,6 +20,7 @@ import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -33,11 +34,13 @@ public class McpToolProviderProviderRegistrar implements ChildResourceDefinition
     public static final StringListAttributeDefinition MCP_CLIENTS = new StringListAttributeDefinition.Builder("mcp-clients")
             .setCapabilityReference("org.wildfly.ai.mcp.client")
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition FAIL_IF_ONE_SERVER_FAILS = SimpleAttributeDefinitionBuilder.create("fail-if-one-server-fails", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
             .setDefaultValue(ModelNode.FALSE)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(FAIL_IF_ONE_SERVER_FAILS, MCP_CLIENTS);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/memory/ChatMemoryProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/memory/ChatMemoryProviderRegistrar.java
@@ -16,6 +16,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 
 import org.jboss.as.controller.operations.validation.EnumValidator;
@@ -31,14 +32,17 @@ public class ChatMemoryProviderRegistrar implements ChildResourceDefinitionRegis
     public static final SimpleAttributeDefinition USE_HTTP_SESSION = new SimpleAttributeDefinitionBuilder("use-http-session", ModelType.BOOLEAN, true)
             .setDefaultValue(ModelNode.TRUE)
             .setAllowExpression(true)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition SIZE = new SimpleAttributeDefinitionBuilder("size", ModelType.INT, false)
             .setAllowExpression(true)
             .setValidator(IntRangeValidator.POSITIVE)
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition TYPE = new SimpleAttributeDefinitionBuilder("type", ModelType.STRING, false)
             .setAllowExpression(true)
             .setValidator(EnumValidator.create(org.wildfly.extension.ai.injection.memory.WildFlyChatMemoryProviderConfig.ChatMemoryType.class))
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
 

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/rag/retriever/EmbeddingStoreContentRetrieverProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/rag/retriever/EmbeddingStoreContentRetrieverProviderRegistrar.java
@@ -17,6 +17,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.ai.Capabilities;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -35,19 +36,23 @@ public class EmbeddingStoreContentRetrieverProviderRegistrar implements ChildRes
             .setAllowExpression(true)
             .setCapabilityReference(EMBEDDING_STORE_PROVIDER_DESCRIPTOR.getName())
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition EMBEDDING_MODEL = SimpleAttributeDefinitionBuilder.create("embedding-model", ModelType.STRING, false)
             .setAllowExpression(true)
             .setCapabilityReference(EMBEDDING_MODEL_PROVIDER_DESCRIPTOR.getName())
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition MAX_RESULTS = SimpleAttributeDefinitionBuilder.create("max-results", ModelType.INT, true)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition MIN_SCORE = SimpleAttributeDefinitionBuilder.create("min-score", ModelType.DOUBLE, true)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 //    public static final SimpleAttributeDefinition FILTER = SimpleAttributeDefinitionBuilder.create("filter", ModelType.STRING, true)
 //            .setAllowExpression(true)

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/rag/retriever/Neo4JContentRetrieverProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/rag/retriever/Neo4JContentRetrieverProviderRegistrar.java
@@ -21,6 +21,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.ai.Capabilities;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -35,10 +36,12 @@ public class Neo4JContentRetrieverProviderRegistrar implements ChildResourceDefi
             .setAllowExpression(true)
             .setCapabilityReference(CHAT_MODEL_PROVIDER_DESCRIPTOR.getName())
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition PROMPT_TEMPLATE = SimpleAttributeDefinitionBuilder.create("prompt-template", ModelType.STRING, true)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(BOLT_URL, CHAT_LANGUAGE_MODEL, CREDENTIAL_REFERENCE, USERNAME, PROMPT_TEMPLATE);

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/rag/retriever/WebSearchContentContentRetrieverProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/rag/retriever/WebSearchContentContentRetrieverProviderRegistrar.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.ai.Capabilities;
@@ -44,18 +45,19 @@ public class WebSearchContentContentRetrieverProviderRegistrar implements ChildR
 
     public static final SimpleAttributeDefinition GOOGLE_SEARCH_ENGINE = new ObjectTypeAttributeDefinition.Builder("google",
             API_KEY,
-            SimpleAttributeDefinitionBuilder.create(CONNECT_TIMEOUT).setDefaultValue(new ModelNode(60000L)).build(),
-            SimpleAttributeDefinitionBuilder.create("custom-search-id", ModelType.STRING, true).build(),
-            SimpleAttributeDefinitionBuilder.create("include-images", ModelType.BOOLEAN, true).build(),
+            SimpleAttributeDefinitionBuilder.create(CONNECT_TIMEOUT).setDefaultValue(new ModelNode(60000L)).setStability(Stability.EXPERIMENTAL).build(),
+            SimpleAttributeDefinitionBuilder.create("custom-search-id", ModelType.STRING, true).setStability(Stability.EXPERIMENTAL).build(),
+            SimpleAttributeDefinitionBuilder.create("include-images", ModelType.BOOLEAN, true).setStability(Stability.EXPERIMENTAL).build(),
             LOG_REQUESTS,
             LOG_RESPONSES,
             MAX_RETRIES,
-            SimpleAttributeDefinitionBuilder.create("site-restrict", ModelType.BOOLEAN, true).build())
+            SimpleAttributeDefinitionBuilder.create("site-restrict", ModelType.BOOLEAN, true).setStability(Stability.EXPERIMENTAL).build())
                 .setAttributeMarshaller(AttributeMarshaller.ATTRIBUTE_OBJECT)
                 .setAttributeParser(AttributeParser.OBJECT_PARSER)
                 .setAllowExpression(true)
                 .addAlternatives("tavily")
                 .setRestartAllServices()
+                .setStability(Stability.EXPERIMENTAL)
                 .build();
 
     public static final SimpleAttributeDefinition TAVILY_SEARCH_ENGINE = new ObjectTypeAttributeDefinition.Builder("tavily",
@@ -67,26 +69,30 @@ public class WebSearchContentContentRetrieverProviderRegistrar implements ChildR
                 .setMinSize(0)
                 .setAllowExpression(true)
                 .setRestartAllServices()
+                .setStability(Stability.EXPERIMENTAL)
                 .build(),
-            SimpleAttributeDefinitionBuilder.create("include-answer", ModelType.BOOLEAN, true).build(),
+            SimpleAttributeDefinitionBuilder.create("include-answer", ModelType.BOOLEAN, true).setStability(Stability.EXPERIMENTAL).build(),
             StringListAttributeDefinition.Builder.of("include-domains")
                 .setRequired(false)
                 .setMinSize(0)
                 .setAllowExpression(true)
                 .setRestartAllServices()
+                .setStability(Stability.EXPERIMENTAL)
                 .build(),
-            SimpleAttributeDefinitionBuilder.create("include-raw-content", ModelType.BOOLEAN, true).build(),
-            SimpleAttributeDefinitionBuilder.create("search-depth", ModelType.STRING, true).setAllowedValues("basic", "advanced").build())
+            SimpleAttributeDefinitionBuilder.create("include-raw-content", ModelType.BOOLEAN, true).setStability(Stability.EXPERIMENTAL).build(),
+            SimpleAttributeDefinitionBuilder.create("search-depth", ModelType.STRING, true).setAllowedValues("basic", "advanced").setStability(Stability.EXPERIMENTAL).build())
                 .setAllowExpression(true)
                 .addAlternatives("google")
                 .setRestartAllServices()
                 .setAttributeMarshaller(AttributeMarshaller.ATTRIBUTE_OBJECT)
                 .setAttributeParser(AttributeParser.OBJECT_PARSER)
+                .setStability(Stability.EXPERIMENTAL)
                 .build();
 
     public static final SimpleAttributeDefinition MAX_RESULTS = SimpleAttributeDefinitionBuilder.create("max-results", ModelType.INT, true)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(GOOGLE_SEARCH_ENGINE, MAX_RESULTS, TAVILY_SEARCH_ENGINE);

--- a/wildfly-ai/subsystem/src/main/resources/schema/wildfly-ai_experimental_1_0.xsd
+++ b/wildfly-ai/subsystem/src/main/resources/schema/wildfly-ai_experimental_1_0.xsd
@@ -6,8 +6,8 @@
 -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="urn:jboss:domain:ai:1.0"
-           xmlns="urn:jboss:domain:ai:1.0"
+           targetNamespace="urn:jboss:domain:ai:experimental:1.0"
+           xmlns="urn:jboss:domain:ai:experimental:1.0"
            xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"

--- a/wildfly-ai/subsystem/src/test/resources/org/wildfly/extension/ai/ai-experimental-1.0.xml
+++ b/wildfly-ai/subsystem/src/test/resources/org/wildfly/extension/ai/ai-experimental-1.0.xml
@@ -3,7 +3,7 @@
 ~ SPDX-License-Identifier: Apache-2.0
 -->
 
-<subsystem xmlns="urn:jboss:domain:ai:1.0">
+<subsystem xmlns="urn:jboss:domain:ai:experimental:1.0">
     <chat-language-models>
         <gemini-chat-model name="gemini" api-key="${env.GEMINI_API_KEY:key}" include-code-execution-output="true" harassment="${org.wildfly.ai.gemini.harassment,env.GEMINI_HARASSMENT:BLOCK_LOW_AND_ABOVE}" log-requests="${org.wildfly.ai.gemini.chat.log,env.GEMINI_CHAT_LOG:true}" log-responses="${org.wildfly.ai.gemini.chat.log,env.GEMINI_CHAT_LOG:true}" model-name="${org.wildfly.ai.gemini.chat.model.name,env.GEMINI_CHAT_MODEL_NAME:gpt-4o-mini}" streaming="false" temperature="${org.wildfly.ai.gemini.chat.temperature,env.GEMINI_CHAT_TEMPERATURE:0.9}" executor-service="default"/>
         <github-chat-model name="github" api-key="${env.GITHUB_API_KEY:key}" endpoint="${org.wildfly.ai.github.chat.url,env.GITHUB_CHAT_URL:https://models.inference.ai.azure.com}" log-requests-responses="${org.wildfly.ai.github.chat.log,env.GITHUB_CHAT_LOG:true}" model-name="${org.wildfly.ai.github.chat.model.name,env.GITHUB_CHAT_MODEL_NAME:gpt-4o-mini}" streaming="false" temperature="${org.wildfly.ai.github.chat.temperature,env.GITHUB_CHAT_TEMPERATURE:0.9}"/>

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfigurationProviderRegistrar.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfigurationProviderRegistrar.java
@@ -17,6 +17,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -30,19 +31,23 @@ public class MCPEndpointConfigurationProviderRegistrar implements ChildResourceD
     public static final SimpleAttributeDefinition SSE_PATH = SimpleAttributeDefinitionBuilder.create("sse-path", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition MESSAGES_PATH = SimpleAttributeDefinitionBuilder.create("messages-path", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition STREAMABLE_PATH = SimpleAttributeDefinitionBuilder.create("streamable-path", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition PAGE_SIZE = SimpleAttributeDefinitionBuilder.create("page-size", ModelType.INT, true)
             .setAllowExpression(true)
             .setDefaultValue(new org.jboss.dmr.ModelNode(0))
             .setRestartAllServices()
+            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(MESSAGES_PATH, SSE_PATH, STREAMABLE_PATH, PAGE_SIZE);
 

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPSubsystemSchema.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPSubsystemSchema.java
@@ -10,6 +10,7 @@ import org.jboss.as.controller.persistence.xml.SubsystemResourceRegistrationXMLE
 import org.jboss.as.controller.persistence.xml.SubsystemResourceXMLSchema;
 import org.jboss.as.controller.xml.VersionedNamespace;
 import org.jboss.as.controller.xml.XMLCardinality;
+import org.jboss.as.version.Stability;
 import org.jboss.staxmapper.IntVersion;
 
 
@@ -24,7 +25,7 @@ enum MCPSubsystemSchema implements SubsystemResourceXMLSchema<MCPSubsystemSchema
     private final ResourceXMLParticleFactory factory = ResourceXMLParticleFactory.newInstance(this);
 
     MCPSubsystemSchema(int major, int minor) {
-        this.namespace = SubsystemSchema.createLegacySubsystemURN(MCPSubsystemRegistrar.NAME, new IntVersion(major, minor));
+        this.namespace = SubsystemSchema.createLegacySubsystemURN(MCPSubsystemRegistrar.NAME, Stability.EXPERIMENTAL, new IntVersion(major, minor));
     }
 
     @Override

--- a/wildfly-mcp/subsystem/src/main/resources/schema/wildfly-mcp_experimental_1_0.xsd
+++ b/wildfly-mcp/subsystem/src/main/resources/schema/wildfly-mcp_experimental_1_0.xsd
@@ -6,8 +6,8 @@
 -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="urn:jboss:domain:mcp:1.0"
-           xmlns="urn:jboss:domain:mcp:1.0"
+           targetNamespace="urn:jboss:domain:mcp:experimental:1.0"
+           xmlns="urn:jboss:domain:mcp:experimental:1.0"
            elementFormDefault="qualified"
            version="1.0">
     <xs:element name="subsystem" type="subsystemType">

--- a/wildfly-mcp/subsystem/src/test/resources/org/wildfly/extension/mcp/mcp-experimental-1.0.xml
+++ b/wildfly-mcp/subsystem/src/test/resources/org/wildfly/extension/mcp/mcp-experimental-1.0.xml
@@ -3,6 +3,6 @@
 ~ SPDX-License-Identifier: Apache-2.0
 -->
 
-<subsystem xmlns="urn:jboss:domain:mcp:1.0">
+<subsystem xmlns="urn:jboss:domain:mcp:experimental:1.0">
     <mcp-server name="server" sse-path="sse" messages-path="messages" streamable-path="stream"/>
 </subsystem>

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmProviderRegistrar.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmProviderRegistrar.java
@@ -20,6 +20,7 @@ import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -36,32 +37,38 @@ public class WasmProviderRegistrar implements ChildResourceDefinitionRegistrar {
                     .setAllowExpression(true)
                     .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
                     .addArbitraryDescriptor(FILESYSTEM_PATH, ModelNode.TRUE)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     protected static final SimpleAttributeDefinition WASM_RELATIVE_TO
             = new SimpleAttributeDefinitionBuilder("relative-to", ModelType.STRING, true)
                     .setXmlName("relative-to")
                     .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
                     .setCapabilityReference(PathManager.PATH_SERVICE_DESCRIPTOR.getName())
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     protected static final SimpleAttributeDefinition WASM_AOT
             = new SimpleAttributeDefinitionBuilder("use-aot", ModelType.BOOLEAN, true)
                     .setAllowExpression(true)
                     .setDefaultValue(ModelNode.TRUE)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     protected static final SimpleAttributeDefinition WASM_MEMORY_CONSTRAINTS_MINIMAL
             = new SimpleAttributeDefinitionBuilder("min-memory-contraint", ModelType.INT, true)
                     .setAllowExpression(true)
                     .setValidator(IntRangeValidator.POSITIVE)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     protected static final SimpleAttributeDefinition WASM_MEMORY_CONSTRAINTS_MAXIMAL
             = new SimpleAttributeDefinitionBuilder("max-memory-contraint", ModelType.INT, true)
                     .setAllowExpression(true)
                     .setValidator(IntRangeValidator.POSITIVE)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
     protected static final StringListAttributeDefinition WASM_ALLOWED_HOSTS
             = new StringListAttributeDefinition.Builder("allowed-hosts")
                     .setAllowExpression(true)
                     .setRequired(false)
+                    .setStability(Stability.EXPERIMENTAL)
                     .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(WASM_ALLOWED_HOSTS, WASM_AOT, 

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemSchema.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmSubsystemSchema.java
@@ -10,6 +10,7 @@ import org.jboss.as.controller.persistence.xml.SubsystemResourceRegistrationXMLE
 import org.jboss.as.controller.persistence.xml.SubsystemResourceXMLSchema;
 import org.jboss.as.controller.xml.VersionedNamespace;
 import org.jboss.as.controller.xml.XMLCardinality;
+import org.jboss.as.version.Stability;
 import org.jboss.staxmapper.IntVersion;
 
 /**
@@ -23,7 +24,7 @@ enum WasmSubsystemSchema implements SubsystemResourceXMLSchema<WasmSubsystemSche
     private final ResourceXMLParticleFactory factory = ResourceXMLParticleFactory.newInstance(this);
 
     WasmSubsystemSchema(int major, int minor) {
-        this.namespace = SubsystemSchema.createLegacySubsystemURN(WasmSubsystemRegistrar.NAME, new IntVersion(major, minor));
+        this.namespace = SubsystemSchema.createLegacySubsystemURN(WasmSubsystemRegistrar.NAME, Stability.EXPERIMENTAL, new IntVersion(major, minor));
     }
 
     @Override

--- a/wildfly-wasm/subsystem/src/main/resources/schema/wildfly-wasm_experimental_1_0.xsd
+++ b/wildfly-wasm/subsystem/src/main/resources/schema/wildfly-wasm_experimental_1_0.xsd
@@ -6,8 +6,8 @@
 -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="urn:jboss:domain:wasm:1.0"
-           xmlns="urn:jboss:domain:wasm:1.0"
+           targetNamespace="urn:jboss:domain:wasm:experimental:1.0"
+           xmlns="urn:jboss:domain:wasm:experimental:1.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">

--- a/wildfly-wasm/subsystem/src/test/resources/org/wildfly/extension/wasm/wasm-experimental-1.0.xml
+++ b/wildfly-wasm/subsystem/src/test/resources/org/wildfly/extension/wasm/wasm-experimental-1.0.xml
@@ -3,7 +3,7 @@
 ~ SPDX-License-Identifier: Apache-2.0
 -->
 
-<subsystem xmlns="urn:jboss:domain:wasm:1.0">
+<subsystem xmlns="urn:jboss:domain:wasm:experimental:1.0">
     <wasm-tool name="chicory" path="/home/ehugonne/dev/AI/examples/greet.wasm"/>
     <wasm-tool name="dice" path="/home/ehugonne/dev/AI/examples/roll-dice.wasm"/>
     <wasm-tool name="pizza" path="/home/ehugonne/dev/AI/examples/hawaiian-pizza.wasm"/>


### PR DESCRIPTION
Attributes and operations did not inherit the experimental stability level from their parent subsystem resource. This adds explicit setStability(Stability.EXPERIMENTAL) to every attribute definition and operation definition across the ai, mcp, and wasm subsystems.