### PR TITLE
chore: Centralize testsuite dependency and plugin management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,21 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- JUnit BOM -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${version.junit}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.assertj}</version>
+            </dependency>
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-ai-feature-pack</artifactId>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -15,48 +15,13 @@
     <description>Integration tests for WildFly AI Feature Pack using Arquillian and Testcontainers</description>
 
     <properties>
-        <version.arquillian>1.10.0.Final</version.arquillian>
-        <version.wildfly.arquillian>5.1.0.Final</version.wildfly.arquillian>
-        <version.testcontainers>1.21.4</version.testcontainers>
         <version.wildfly.glow>1.5.2.Final</version.wildfly.glow>
-        <version.maven.surefire>3.5.3</version.maven.surefire>
         <jboss.home>${project.build.directory}/server</jboss.home>
 
         <!-- Ollama configuration for tests - defaults to local instance -->
         <ollama.base.url>http://localhost:11434</ollama.base.url>
         <ollama.model.name>llama3.2:1b</ollama.model.name>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- Testcontainers BOM -->
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${version.testcontainers}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <!-- Arquillian BOM -->
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${version.arquillian}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <!-- JUnit BOM -->
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${version.junit}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- JUnit 5 -->
@@ -201,7 +166,6 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.wildfly.maven.plugin}</version>
                 <executions>
                     <execution>
                         <id>provision-server-otel</id>

--- a/testsuite/mcp/pom.xml
+++ b/testsuite/mcp/pom.xml
@@ -15,32 +15,8 @@
     <description>Integration tests for WildFly MCP Server subsystem</description>
 
     <properties>
-        <version.junit>5.11.4</version.junit>
-        <version.arquillian>1.10.0.Final</version.arquillian>
-        <version.wildfly.arquillian>5.1.0.Final</version.wildfly.arquillian>
-        <version.assertj>3.26.3</version.assertj>
-        <version.maven.surefire>3.5.2</version.maven.surefire>
         <jboss.home>${project.build.directory}/server</jboss.home>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${version.arquillian}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${version.junit}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- JUnit 5 -->
@@ -145,7 +121,6 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.wildfly.maven.plugin}</version>
                 <executions>
                     <execution>
                         <id>provision-server</id>
@@ -187,13 +162,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <!-- Maven Surefire Plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.maven.surefire}</version>
             </plugin>
         </plugins>
     </build>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -16,7 +16,50 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <version.arquillian>1.10.0.Final</version.arquillian>
+        <version.wildfly.arquillian>5.1.0.Final</version.wildfly.arquillian>
+        <version.maven.surefire>3.5.5</version.maven.surefire>
+        <version.testcontainers>1.21.4</version.testcontainers>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Arquillian BOM -->
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${version.arquillian}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Testcontainers BOM -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${version.testcontainers}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.wildfly.maven.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.maven.surefire}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
     <modules>
         <module>mcp</module>


### PR DESCRIPTION
Move shared dependency versions (Arquillian 1.10.0, Testcontainers 1.21.4) and plugin versions (wildfly-maven-plugin, maven-surefire) from child modules into testsuite/pom.xml via dependencyManagement and pluginManagement.

Promote JUnit BOM and AssertJ to the root POM dependencyManagement so all modules inherit consistent test library versions.

Upgrade maven-surefire-plugin from 3.5.2/3.5.3 to 3.5.5.