### PR TITLE
chore(deps): Upgrade java-mcp-annotations to 1.0.0-Beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,27 @@
 
 #### MCP Server Annotation API
 
-The MCP server annotation API has been replaced by the **[`org.mcp-java:mcp-annotations`](https://github.com/mcp-java/java-mcp-annotations)** library. This change standardizes annotations and APIs across Java runtimes, decoupling the MCP annotation contract from the WildFly-specific `wildfly-mcp/api` module.
+The MCP server annotation API has been replaced by the **`org.mcp-java:mcp-server-api`** library from the [java-mcp-annotations project](https://github.com/mcp-java/java-mcp-annotations). This change standardizes annotations and APIs across Java runtimes, decoupling the MCP annotation contract from the WildFly-specific `wildfly-mcp/api` module.
 
 **Migration steps:**
 
-1. Replace the `wildfly-mcp/api` dependency with `org.mcp-java:mcp-annotations`:
+1. Replace the `wildfly-mcp/api` dependency with `org.mcp-java:mcp-server-api`:
 
    ```xml
    <dependency>
        <groupId>org.mcp-java</groupId>
-       <artifactId>mcp-annotations</artifactId>
+       <artifactId>mcp-server-api</artifactId>
        <scope>provided</scope>
    </dependency>
    ```
 
-2. Update your imports to use the new package names from `org.mcp-java:mcp-annotations`.
+2. Update your imports to use the new `org.mcp_java.server.*` package names.
 
 See the [java-mcp-annotations](https://github.com/mcp-java/java-mcp-annotations) project for the full API reference.
 
 ### New Features
 
-* Standardized MCP annotations via [`org.mcp-java:mcp-annotations`](https://github.com/mcp-java/java-mcp-annotations) for cross-runtime compatibility.
+* Standardized MCP annotations via `org.mcp-java:mcp-server-api` library from the [java-mcp-annotations project](https://github.com/mcp-java/java-mcp-annotations) for cross-runtime compatibility.
 * Async execution support: all chat model layers now support the `executor-service` attribute for configuring a `ManagedExecutorService`.
 * WildFly Preview compatibility.
 

--- a/README.md
+++ b/README.md
@@ -96,24 +96,24 @@ Breaking Changes
 
 ### MCP Server Annotations (0.10.0+)
 
-The MCP server annotation API has moved to the **[`org.mcp-java:mcp-annotations`](https://github.com/mcp-java/java-mcp-annotations)** library to provide standardized annotations and APIs across Java runtimes.
+The MCP server annotation API has moved to the **[`org.mcp-java:mcp-server-api`](https://github.com/mcp-java/java-mcp-annotations)** library to provide standardized annotations and APIs across Java runtimes.
 
 If you were using the previous `wildfly-mcp/api` module annotations, you must update your dependency:
 
 ```xml
 <dependency>
     <groupId>org.mcp-java</groupId>
-    <artifactId>mcp-annotations</artifactId>
+    <artifactId>mcp-server-api</artifactId>
     <scope>provided</scope>
 </dependency>
 ```
 
-The annotation classes and package names have changed accordingly. See the [java-mcp-annotations](https://github.com/mcp-java/java-mcp-annotations) project for the updated API.
+The annotation classes have moved to the `org.mcp_java.server.*` package. See the [java-mcp-annotations](https://github.com/mcp-java/java-mcp-annotations) project for the updated API.
 
 Recent Features
 ========================
 
-* **Standardized MCP Annotations**: MCP server annotations are now provided by [`org.mcp-java:mcp-annotations`](https://github.com/mcp-java/java-mcp-annotations) for cross-runtime compatibility.
+* **Standardized MCP Annotations**: MCP server annotations are now provided by [`org.mcp-java:mcp-server-api`](https://github.com/mcp-java/java-mcp-annotations) for cross-runtime compatibility.
 * **Async Execution Support**: All chat model layers now support the `executor-service` attribute, allowing you to configure a ManagedExecutorService for asynchronous AI operations.
 * **WildFly Preview Support**: The feature pack is now compatible with WildFly Preview releases.
 * **Enhanced MCP Support**: Added MCP server capabilities and multiple transport options (SSE, stdio, streamable).
@@ -238,10 +238,10 @@ The feature pack can act as an MCP client with support for multiple transports:
 ## MCP Server Support
 
 The feature pack also supports exposing your Jakarta EE application as an MCP Server using the `mcp-server` Galleon layer.
-What you need to do in that case is to use the `org.mcp-java:mcp-annotations` artifact as a provided dependency and annotate the code you want to expose with the annotations provided by the API.
-For more information about `org.mcp-java:mcp-annotations` you can check [java-mcp-annotations](https://github.com/mcp-java/java-mcp-annotations).
+What you need to do in that case is to use the `org.mcp-java:mcp-server-api` artifact as a provided dependency and annotate the code you want to expose with the annotations from the `org.mcp_java.server.*` package.
+For more information about `org.mcp-java:mcp-server-api` you can check [java-mcp-annotations](https://github.com/mcp-java/java-mcp-annotations).
 
-> **Breaking change (0.10.0+):** The MCP annotation API has moved from the `wildfly-mcp/api` module to [`org.mcp-java:mcp-annotations`](https://github.com/mcp-java/java-mcp-annotations) for standardized annotations and APIs across runtimes. Update your dependency and package imports accordingly.
+> **Breaking change (0.10.0+):** The MCP annotation API has moved from the `wildfly-mcp/api` module to [`org.mcp-java:mcp-server-api`](https://github.com/mcp-java/java-mcp-annotations) for standardized annotations and APIs across runtimes. Update your dependency and package imports accordingly.
 
 You may want to take a look at [wildfly-weather](https://github.com/ehsavoie/wildfly-weather) example.
 

--- a/ai-feature-pack/pom.xml
+++ b/ai-feature-pack/pom.xml
@@ -36,10 +36,6 @@
         </dependency>
         <dependency>
             <groupId>org.mcp-java</groupId>
-            <artifactId>mcp-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mcp-java</groupId>
             <artifactId>mcp-model</artifactId>
         </dependency>
         <dependency>

--- a/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
@@ -9,7 +9,7 @@
         <prop name="org.wildfly.description" value="Support for MCP Server"/>
         <prop name="org.wildfly.stability" value="experimental"/>
         <prop name="org.wildfly.rule.class" value="org.mcp_java.*"/>
-        <prop name="org.wildfly.rule.annotations" value="org.mcp_java.annotations.*"/>
+        <prop name="org.wildfly.rule.annotations" value="org.mcp_java.server.*"/>
     </props>
     <dependencies>
         <layer name="ee-concurrency"/>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mcp/injection/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mcp/injection/main/module.xml
@@ -14,7 +14,6 @@
 
     <resources>
         <artifact name="${org.wildfly.generative-ai:wildfly-mcp-injection}"/>
-        <artifact name="${org.mcp-java:mcp-annotations}"/>
         <artifact name="${org.mcp-java:mcp-model}"/>
         <artifact name="${org.mcp-java:mcp-server-api}"/>
     </resources>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -32,18 +32,6 @@
             </dependency>
             <dependency>
                 <groupId>org.mcp-java</groupId>
-                <artifactId>mcp-annotations</artifactId>
-                <version>${version.org.mcp-java}</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.mcp-java</groupId>
                 <artifactId>mcp-model</artifactId>
                 <version>${version.org.mcp-java}</version>
                 <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <version.net.java.dev.jna>5.13.0</version.net.java.dev.jna>
         <version.org.extism.sdk.chicory-sdk>0.3.0</version.org.extism.sdk.chicory-sdk>
         <version.org.jetbrains.kotlin>2.2.0</version.org.jetbrains.kotlin>
-        <version.org.mcp-java>1.0.0-Beta1</version.org.mcp-java>
+        <version.org.mcp-java>1.0.0-Beta2</version.org.mcp-java>
         <version.org.neo4j.cypher>2025.2.7</version.org.neo4j.cypher>
         <version.org.neo4j.driver>6.0.5</version.org.neo4j.driver>
         <version.org.ow2.asm>9.9.1</version.org.ow2.asm>
@@ -146,17 +146,6 @@
                 <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-ai-subsystem</artifactId>
                 <version>${project.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.mcp-java</groupId>
-                <artifactId>mcp-annotations</artifactId>
-                <version>${version.org.mcp-java}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/testsuite/mcp/pom.xml
+++ b/testsuite/mcp/pom.xml
@@ -74,12 +74,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- MCP annotations for test beans -->
-        <dependency>
-            <groupId>org.mcp-java</groupId>
-            <artifactId>mcp-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
+        <!-- MCP server API for test beans -->
         <dependency>
             <groupId>org.mcp-java</groupId>
             <artifactId>mcp-model</artifactId>

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationTool.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationTool.java
@@ -4,8 +4,8 @@
  */
 package org.wildfly.ai.test.mcp;
 
-import org.mcp_java.annotations.tools.Tool;
-import org.mcp_java.annotations.tools.ToolArg;
+import org.mcp_java.server.tools.Tool;
+import org.mcp_java.server.tools.ToolArg;
 import org.wildfly.extension.mcp.injection.elicitation.ElicitationRequest;
 import org.wildfly.extension.mcp.injection.elicitation.ElicitationResponse;
 import org.wildfly.extension.mcp.injection.elicitation.ElicitationSender;

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPLoggingTool.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPLoggingTool.java
@@ -4,8 +4,8 @@
  */
 package org.wildfly.ai.test.mcp;
 
-import org.mcp_java.annotations.tools.Tool;
-import org.mcp_java.annotations.tools.ToolArg;
+import org.mcp_java.server.tools.Tool;
+import org.mcp_java.server.tools.ToolArg;
 import org.mcp_java.server.McpLog;
 
 public class TestMCPLoggingTool {

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPPaginationFixtures.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPPaginationFixtures.java
@@ -5,11 +5,11 @@
 package org.wildfly.ai.test.mcp;
 
 import java.util.List;
-import org.mcp_java.annotations.prompts.Prompt;
-import org.mcp_java.annotations.prompts.PromptArg;
-import org.mcp_java.annotations.resources.Resource;
-import org.mcp_java.annotations.tools.Tool;
-import org.mcp_java.annotations.tools.ToolArg;
+import org.mcp_java.server.prompts.Prompt;
+import org.mcp_java.server.prompts.PromptArg;
+import org.mcp_java.server.resources.Resource;
+import org.mcp_java.server.tools.Tool;
+import org.mcp_java.server.tools.ToolArg;
 import org.mcp_java.model.content.TextContent;
 import org.mcp_java.model.prompt.PromptMessage;
 import org.mcp_java.model.resource.ResourceContents;

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPPrompt.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPPrompt.java
@@ -5,8 +5,8 @@
 package org.wildfly.ai.test.mcp;
 
 import java.util.List;
-import org.mcp_java.annotations.prompts.Prompt;
-import org.mcp_java.annotations.prompts.PromptArg;
+import org.mcp_java.server.prompts.Prompt;
+import org.mcp_java.server.prompts.PromptArg;
 import org.mcp_java.model.content.TextContent;
 import org.mcp_java.model.prompt.PromptMessage;
 

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPResource.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPResource.java
@@ -4,7 +4,7 @@
  */
 package org.wildfly.ai.test.mcp;
 
-import org.mcp_java.annotations.resources.Resource;
+import org.mcp_java.server.resources.Resource;
 import org.mcp_java.model.resource.ResourceContents;
 
 public class TestMCPResource {

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPTool.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPTool.java
@@ -4,8 +4,8 @@
  */
 package org.wildfly.ai.test.mcp;
 
-import org.mcp_java.annotations.tools.Tool;
-import org.mcp_java.annotations.tools.ToolArg;
+import org.mcp_java.server.tools.Tool;
+import org.mcp_java.server.tools.ToolArg;
 
 public class TestMCPTool {
 

--- a/wildfly-mcp/subsystem/pom.xml
+++ b/wildfly-mcp/subsystem/pom.xml
@@ -51,10 +51,6 @@
         </dependency>
         <dependency>
             <groupId>org.mcp-java</groupId>
-            <artifactId>mcp-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mcp-java</groupId>
             <artifactId>mcp-model</artifactId>
         </dependency>
         <dependency>

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPServerDependencyProcessor.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPServerDependencyProcessor.java
@@ -32,16 +32,16 @@ import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
 import org.wildfly.extension.mcp.injection.tool.MethodMetadata;
 import org.wildfly.extension.mcp.injection.elicitation.ElicitationSender;
 import org.mcp_java.server.McpLog;
-import org.mcp_java.annotations.tools.Tool;
-import org.mcp_java.annotations.tools.ToolArg;
-import org.mcp_java.annotations.prompts.Prompt;
-import org.mcp_java.annotations.prompts.PromptArg;
-import org.mcp_java.annotations.resources.Resource;
-import org.mcp_java.annotations.resources.ResourceTemplate;
-import org.mcp_java.annotations.resources.ResourceTemplateArg;
-import org.mcp_java.annotations.completion.CompletePrompt;
-import org.mcp_java.annotations.completion.CompleteResourceTemplate;
-import org.mcp_java.annotations.completion.CompleteArg;
+import org.mcp_java.server.tools.Tool;
+import org.mcp_java.server.tools.ToolArg;
+import org.mcp_java.server.prompts.Prompt;
+import org.mcp_java.server.prompts.PromptArg;
+import org.mcp_java.server.resources.Resource;
+import org.mcp_java.server.resources.ResourceTemplate;
+import org.mcp_java.server.resources.ResourceTemplateArg;
+import org.mcp_java.server.completion.CompletePrompt;
+import org.mcp_java.server.completion.CompleteResourceTemplate;
+import org.mcp_java.server.completion.CompleteArg;
 
 public class MCPServerDependencyProcessor implements DeploymentUnitProcessor {
 


### PR DESCRIPTION
  The mcp-annotations artifact has been merged into mcp-server-api.
  Update all dependencies and Java imports accordingly:
  - Remove mcp-annotations artifact references from POMs and module.xml
  - Rename package org.mcp_java.annotations.* to org.mcp_java.server.*
  - Update layer-spec annotation rule to match new package