### PR TITLE
feat!: Move MCP server features to default stability level 

### DIFF
--- a/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
@@ -17,9 +17,6 @@
     <feature spec="subsystem.mcp">
         <feature spec="subsystem.mcp.mcp-server">
             <param name="mcp-server" value="server"/>
-            <param name="sse-path" value="sse"/>
-            <param name="messages-path" value="messages"/>
-            <param name="streamable-path" value="stream"/>
         </feature>
     </feature>
 </layer-spec>

--- a/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
@@ -7,7 +7,7 @@
     <props>
         <prop name="org.wildfly.category" value="Model Context Protocol Server"/>
         <prop name="org.wildfly.description" value="Support for MCP Server"/>
-        <prop name="org.wildfly.stability" value="experimental"/>
+        <prop name="org.wildfly.stability" value="default"/>
         <prop name="org.wildfly.rule.class" value="org.mcp_java.*"/>
         <prop name="org.wildfly.rule.annotations" value="org.mcp_java.annotations.*"/>
     </props>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/com/github/victools/jsonschema-generator/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/com/github/victools/jsonschema-generator/main/module.xml
@@ -12,7 +12,7 @@
              though it may not be supported by product vendors
              (because its APIs could change without prior notice). -->
         <property name="jboss.api" value="private"/>
-        <property name="jboss.stability" value="experimental"/>
+        <property name="jboss.stability" value="default"/>
     </properties>
 
     <resources>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mcp/injection/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mcp/injection/main/module.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <property name="jboss.api" value="private"/>
-        <property name="jboss.stability" value="experimental"/>
+        <property name="jboss.stability" value="default"/>
     </properties>
 
     <resources>

--- a/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mcp/main/module.xml
+++ b/ai-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mcp/main/module.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <property name="jboss.api" value="private"/>
-        <property name="jboss.stability" value="experimental"/>
+        <property name="jboss.stability" value="default"/>
     </properties>
 
     <resources>

--- a/ai-feature-pack/wildfly-feature-pack-build.xml
+++ b/ai-feature-pack/wildfly-feature-pack-build.xml
@@ -4,6 +4,7 @@
 -->
 
 <build xmlns="urn:wildfly:feature-pack-build:3.5" producer="org.wildfly.generative-ai:wildfly-ai-feature-pack">
+
     <transitive>
         <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack" allowedFamily="wildfly:jakarta-ee-10+">
             <name>org.wildfly:wildfly-ee-galleon-pack</name>

--- a/ai-feature-pack/wildfly-feature-pack-build.xml
+++ b/ai-feature-pack/wildfly-feature-pack-build.xml
@@ -4,7 +4,6 @@
 -->
 
 <build xmlns="urn:wildfly:feature-pack-build:3.5" producer="org.wildfly.generative-ai:wildfly-ai-feature-pack">
-
     <transitive>
         <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack" allowedFamily="wildfly:jakarta-ee-10+">
             <name>org.wildfly:wildfly-ee-galleon-pack</name>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <version.org.wildfly.core>31.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>8.1.0.Final</version.org.wildfly.galleon-plugins>
-        <version.wildfly.maven.plugin>5.1.5.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>6.0.0.Final</version.wildfly.maven.plugin>
 
         <version.ai.djl>0.36.0</version.ai.djl>
         <version.com.azure.azure-ai-inference>1.0.0-beta.5</version.com.azure.azure-ai-inference>

--- a/testsuite/mcp/pom.xml
+++ b/testsuite/mcp/pom.xml
@@ -130,9 +130,9 @@
                         </goals>
                         <configuration>
                             <provisioning-file>${project.build.testOutputDirectory}/provisioning.xml</provisioning-file>
-                            <stability>experimental</stability>
                             <galleon-options>
                                 <jboss-fork-embedded>true</jboss-fork-embedded>
+                                <stability-level>default</stability-level>
                             </galleon-options>
                         </configuration>
                     </execution>

--- a/testsuite/mcp/src/test/resources/arquillian.xml
+++ b/testsuite/mcp/src/test/resources/arquillian.xml
@@ -11,7 +11,7 @@
             <property name="managementPort">9990</property>
             <property name="startupTimeoutInSeconds">120</property>
             <property name="allowConnectingToRunningServer">false</property>
-            <property name="jbossArguments">--stability=experimental</property>
+            <property name="jbossArguments">--stability=default</property>
         </configuration>
     </container>
 

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfiguration.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfiguration.java
@@ -7,10 +7,10 @@ package org.wildfly.extension.mcp;
 /**
  * Encapsulates the configuration of an MCP Server endpoint.
  * @param ssePath: the URL path of the sse endpoint.
- * @param messagesPath: the URL path of the messages' endpoint.
+ * @param messagesPath: the URL path of the messages endpoint.
  * @param streamablePath: the URL path of the streamable endpoint.
  * @param pageSize: maximum number of items per paginated list response; 0 disables pagination.
- * @param timeout: idle connection timeout in seconds; connections inactive for longer than this will be closed.
+ * @param idleTimeout: idle connection timeout in seconds; connections inactive for longer than this will be closed.
  */
-public record MCPEndpointConfiguration(String ssePath, String messagesPath, String streamablePath, int pageSize, long timeout) {
+public record MCPEndpointConfiguration(String ssePath, String messagesPath, String streamablePath, int pageSize, long idleTimeout) {
 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfigurationProviderRegistrar.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfigurationProviderRegistrar.java
@@ -17,7 +17,6 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -31,23 +30,19 @@ public class MCPEndpointConfigurationProviderRegistrar implements ChildResourceD
     public static final SimpleAttributeDefinition SSE_PATH = SimpleAttributeDefinitionBuilder.create("sse-path", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
-            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition MESSAGES_PATH = SimpleAttributeDefinitionBuilder.create("messages-path", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
-            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition STREAMABLE_PATH = SimpleAttributeDefinitionBuilder.create("streamable-path", ModelType.STRING, false)
             .setAllowExpression(true)
             .setRestartAllServices()
-            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition PAGE_SIZE = SimpleAttributeDefinitionBuilder.create("page-size", ModelType.INT, true)
             .setAllowExpression(true)
             .setDefaultValue(new org.jboss.dmr.ModelNode(0))
             .setRestartAllServices()
-            .setStability(Stability.EXPERIMENTAL)
             .build();
     public static final SimpleAttributeDefinition TIMEOUT = SimpleAttributeDefinitionBuilder.create("timeout", ModelType.LONG, true)
             .setAllowExpression(true)

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfigurationProviderRegistrar.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfigurationProviderRegistrar.java
@@ -15,8 +15,12 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.ResourceRegistration;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.LongRangeValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -27,29 +31,33 @@ import org.wildfly.subsystem.resource.operation.ResourceOperationRuntimeHandler;
 
 public class MCPEndpointConfigurationProviderRegistrar implements ChildResourceDefinitionRegistrar {
 
-    public static final SimpleAttributeDefinition SSE_PATH = SimpleAttributeDefinitionBuilder.create("sse-path", ModelType.STRING, false)
+    public static final SimpleAttributeDefinition SSE_PATH = SimpleAttributeDefinitionBuilder.create("sse-path", ModelType.STRING, true)
+            .setDefaultValue(new ModelNode("sse"))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
-    public static final SimpleAttributeDefinition MESSAGES_PATH = SimpleAttributeDefinitionBuilder.create("messages-path", ModelType.STRING, false)
+    public static final SimpleAttributeDefinition MESSAGES_PATH = SimpleAttributeDefinitionBuilder.create("messages-path", ModelType.STRING, true)
+            .setDefaultValue(new ModelNode("messages"))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
-    public static final SimpleAttributeDefinition STREAMABLE_PATH = SimpleAttributeDefinitionBuilder.create("streamable-path", ModelType.STRING, false)
+    public static final SimpleAttributeDefinition STREAMABLE_PATH = SimpleAttributeDefinitionBuilder.create("streamable-path", ModelType.STRING, true)
+            .setDefaultValue(new ModelNode("stream"))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition PAGE_SIZE = SimpleAttributeDefinitionBuilder.create("page-size", ModelType.INT, true)
-            .setAllowExpression(true)
-            .setDefaultValue(new org.jboss.dmr.ModelNode(0))
+            .setDefaultValue(new ModelNode(0))
+            .setValidator(new IntRangeValidator(0, true, true))
             .setRestartAllServices()
             .build();
-    public static final SimpleAttributeDefinition TIMEOUT = SimpleAttributeDefinitionBuilder.create("timeout", ModelType.LONG, true)
-            .setAllowExpression(true)
-            .setDefaultValue(new org.jboss.dmr.ModelNode(1800L))
+    public static final SimpleAttributeDefinition IDLE_TIMEOUT = SimpleAttributeDefinitionBuilder.create("idle-timeout", ModelType.LONG, true)
+            .setDefaultValue(new ModelNode(1800L))
+            .setMeasurementUnit(MeasurementUnit.SECONDS)
+            .setValidator(new LongRangeValidator(0, Long.MAX_VALUE, true, true))
             .setRestartAllServices()
             .build();
-    public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(MESSAGES_PATH, SSE_PATH, STREAMABLE_PATH, PAGE_SIZE, TIMEOUT);
+    public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(MESSAGES_PATH, SSE_PATH, STREAMABLE_PATH, PAGE_SIZE, IDLE_TIMEOUT);
 
     private final ResourceDescriptor descriptor;
     static final String NAME = "mcp-server";

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfigurationProviderServiceConfigurator.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPEndpointConfigurationProviderServiceConfigurator.java
@@ -9,7 +9,7 @@ import static org.wildfly.extension.mcp.MCPEndpointConfigurationProviderRegistra
 import static org.wildfly.extension.mcp.MCPEndpointConfigurationProviderRegistrar.PAGE_SIZE;
 import static org.wildfly.extension.mcp.MCPEndpointConfigurationProviderRegistrar.SSE_PATH;
 import static org.wildfly.extension.mcp.MCPEndpointConfigurationProviderRegistrar.STREAMABLE_PATH;
-import static org.wildfly.extension.mcp.MCPEndpointConfigurationProviderRegistrar.TIMEOUT;
+import static org.wildfly.extension.mcp.MCPEndpointConfigurationProviderRegistrar.IDLE_TIMEOUT;
 
 import java.util.function.Supplier;
 import org.jboss.as.controller.OperationContext;
@@ -23,15 +23,15 @@ public class MCPEndpointConfigurationProviderServiceConfigurator implements Reso
 
     @Override
     public ResourceServiceInstaller configure(OperationContext context, ModelNode model) throws OperationFailedException {
-        final String ssePath = SSE_PATH.resolveModelAttribute(context, model).asString("sse");
-        final String messagesPath = MESSAGES_PATH.resolveModelAttribute(context, model).asString("messages");
-        final String streamablePath = STREAMABLE_PATH.resolveModelAttribute(context, model).asString("streamable");
+        final String ssePath = SSE_PATH.resolveModelAttribute(context, model).asString();
+        final String messagesPath = MESSAGES_PATH.resolveModelAttribute(context, model).asString();
+        final String streamablePath = STREAMABLE_PATH.resolveModelAttribute(context, model).asString();
         final int pageSize = PAGE_SIZE.resolveModelAttribute(context, model).asInt(0);
-        final long timeout = TIMEOUT.resolveModelAttribute(context, model).asLong(1800L);
+        final long idleTimeout = IDLE_TIMEOUT.resolveModelAttribute(context, model).asLong(1800L);
         Supplier<MCPEndpointConfiguration> factory = new Supplier<>() {
             @Override
             public MCPEndpointConfiguration get() {
-                return new MCPEndpointConfiguration(ssePath, messagesPath, streamablePath, pageSize, timeout);
+                return new MCPEndpointConfiguration(ssePath, messagesPath, streamablePath, pageSize, idleTimeout);
             }
         };
         return CapabilityServiceInstaller.builder(MCP_SERVER_PROVIDER_CAPABILITY, factory)

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPSubsystemRegistrar.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPSubsystemRegistrar.java
@@ -29,7 +29,7 @@ class MCPSubsystemRegistrar implements SubsystemResourceDefinitionRegistrar {
 
     static final String NAME = "mcp";
     public static final RuntimeCapability<Void> MCP_CAPABILITY = RuntimeCapability.Builder.of(MCP_CAPABILITY_NAME).setAllowMultipleRegistrations(false).build();
-    static final SubsystemResourceRegistration REGISTRATION = SubsystemResourceRegistration.of(NAME, Stability.EXPERIMENTAL);
+    static final SubsystemResourceRegistration REGISTRATION = SubsystemResourceRegistration.of(NAME, Stability.DEFAULT);
     static final ParentResourceDescriptionResolver RESOLVER = new SubsystemResourceDescriptionResolver(NAME, MCPSubsystemRegistrar.class);
     private static final int PHASE_DEPENDENCIES_MCP = 0x1940;
     private static final int PHASE_POST_MODULE_MCP = 0x3840;

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPSubsystemSchema.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPSubsystemSchema.java
@@ -25,7 +25,7 @@ enum MCPSubsystemSchema implements SubsystemResourceXMLSchema<MCPSubsystemSchema
     private final ResourceXMLParticleFactory factory = ResourceXMLParticleFactory.newInstance(this);
 
     MCPSubsystemSchema(int major, int minor) {
-        this.namespace = SubsystemSchema.createLegacySubsystemURN(MCPSubsystemRegistrar.NAME, Stability.EXPERIMENTAL, new IntVersion(major, minor));
+        this.namespace = SubsystemSchema.createLegacySubsystemURN(MCPSubsystemRegistrar.NAME, Stability.DEFAULT, new IntVersion(major, minor));
     }
 
     @Override

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/ConnectionManager.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/ConnectionManager.java
@@ -71,7 +71,7 @@ public class ConnectionManager {
         }
         for (String id : stale) {
             Logger.getLogger(ConnectionManager.class.getName()).log(Level.INFO,
-                    "Closing stale MCP connection [{0}] due to inactivity timeout", id);
+                    "Closing stale MCP connection [{0}] due to inactivity idleTimeout", id);
             remove(id);
         }
     }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPSseHandlerServiceInstaller.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPSseHandlerServiceInstaller.java
@@ -95,7 +95,7 @@ public class MCPSseHandlerServiceInstaller implements DeploymentServiceInstaller
         Runnable start = new Runnable() {
             @Override
             public void run() {
-                connectionManager.start(configuration.timeout(), lookupScheduledExecutorService());
+                connectionManager.start(configuration.idleTimeout(), lookupScheduledExecutorService());
                 if (oidcSecured) {
                     HttpAuthenticationFactory httpAuthenticationFactory = HttpAuthenticationFactory.builder()
                             .setFactory(getHttpServerAuthenticationMechanismFactory(deploymentUnit))

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ElicitationSenderImpl.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ElicitationSenderImpl.java
@@ -36,7 +36,7 @@ import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
  * <ol>
  *   <li>A {@link CompletableFuture} is registered in the connection's {@link PendingRequestRegistry}.</li>
  *   <li>An {@code elicitation/create} JSON-RPC request is sent to the client via the {@link Responder}.</li>
- *   <li>The tool thread blocks on {@code future.get(timeout)} until the client responds.</li>
+ *   <li>The tool thread blocks on {@code future.get(idleTimeout)} until the client responds.</li>
  *   <li>When the client response arrives, {@link MCPMessageHandler} routes it to
  *       {@link PendingRequestRegistry#handleResponse}, completing the future.</li>
  *   <li>The result is parsed into an {@link ElicitationResponse} and returned to the tool.</li>
@@ -92,7 +92,7 @@ class ElicitationSenderImpl implements ElicitationSender {
         responder.send(Messages.newRequest(requestId, ELICITATION_CREATE, params));
         ROOT_LOGGER.debugf("Elicitation request sent [id: %d, message: %s]", requestId, request.message());
 
-        // Block the tool thread until the client responds or the timeout expires
+        // Block the tool thread until the client responds or the idleTimeout expires
         JsonObject responseMessage;
         try {
             responseMessage = future.get(request.timeoutMillis(), TimeUnit.MILLISECONDS);

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PendingRequestRegistry.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PendingRequestRegistry.java
@@ -68,7 +68,7 @@ public class PendingRequestRegistry {
 
     /**
      * Removes the pending future for {@code id} without completing it.
-     * Used for timeout cleanup.
+     * Used for idleTimeout cleanup.
      *
      * @return {@code true} if a pending entry was removed
      */

--- a/wildfly-mcp/subsystem/src/main/resources/org/wildfly/extension/mcp/LocalDescriptions.properties
+++ b/wildfly-mcp/subsystem/src/main/resources/org/wildfly/extension/mcp/LocalDescriptions.properties
@@ -3,15 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-mcp=The MCP subsystem
+mcp=The MCP (Model Context Protocol) subsystem
 mcp.add=This operation adds the mcp subsystem
 mcp.remove=This operation removes the mcp subsystem
 
-mcp.mcp-server=The MCP server configuration
-mcp.mcp-serve.add=This operation adds the MCP server configuration.
-mcp.mcp-server.remove=This operation removes the MCP server configuration
-mcp.mcp-server.sse-path=This is the context path for the SSE endpoint
-mcp.mcp-server.messages-path=This is the context path for the messages endpoint
-mcp.mcp-server.streamable-path=This is the context path for the streamable endpoint
+mcp.mcp-server=The MCP server configuration.
+mcp.mcp-serve.add=Operation adding a MCP Server.
+mcp.mcp-server.remove=Operation removing a MCP Server
+mcp.mcp-server.sse-path=Context path for the Server-Sent Events (SSE) endpoint of the server.
+mcp.mcp-server.messages-path=Context path for the messages endpoint of the server.
+mcp.mcp-server.streamable-path=Context path for the Streamable HTTP endpoint of the server.
 mcp.mcp-server.page-size=Maximum number of items per paginated list response (tools, prompts, resources, resource templates). A value of 0 disables pagination and returns all items.
-mcp.mcp-server.timeout=Idle connection timeout in seconds. Connections that have been inactive for longer than this value will be automatically closed.
+mcp.mcp-server.idle-timeout=The timeout to detect idle connections. Connections that have been inactive for longer than this value will be automatically closed.

--- a/wildfly-mcp/subsystem/src/main/resources/schema/wildfly-mcp_1_0.xsd
+++ b/wildfly-mcp/subsystem/src/main/resources/schema/wildfly-mcp_1_0.xsd
@@ -6,8 +6,8 @@
 -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="urn:jboss:domain:mcp:experimental:1.0"
-           xmlns="urn:jboss:domain:mcp:experimental:1.0"
+           targetNamespace="urn:jboss:domain:mcp:1.0"
+           xmlns="urn:jboss:domain:mcp:1.0"
            elementFormDefault="qualified"
            version="1.0">
     <xs:element name="subsystem" type="subsystemType">

--- a/wildfly-mcp/subsystem/src/main/resources/schema/wildfly-mcp_1_0.xsd
+++ b/wildfly-mcp/subsystem/src/main/resources/schema/wildfly-mcp_1_0.xsd
@@ -38,34 +38,48 @@
     <xs:complexType name="mcpServerType">
         <xs:annotation>
             <xs:documentation>
-                The MCP endpoints.
+                The MCP server
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="name" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    The name of this provider.
+                    The name of this MCP server.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="sse-path" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
-                    The sse path on the server.
+                    Context path for the Server-Sent Events (SSE) endpoint of the server.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="messages-path" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
-                    The messages path on the server.
+                    Context path for the messages endpoint of the server.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="streamable-path" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
-                    The streamable path on the server.
+                    Context path for the Streamable HTTP endpoint of the server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="page-size" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    Maximum number of items per paginated list response (tools, prompts, resources, resource templates). A value of 0 disables pagination and returns all items.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="idle-timeout" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    The timeout to detect idle connections. Connections that have been inactive for longer than this value will be automatically closed.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/wildfly-mcp/subsystem/src/test/java/org/wildfly/extension/mcp/MCPSubsystemTestCase.java
+++ b/wildfly-mcp/subsystem/src/test/java/org/wildfly/extension/mcp/MCPSubsystemTestCase.java
@@ -27,6 +27,6 @@ public class MCPSubsystemTestCase extends AbstractSubsystemSchemaTest<MCPSubsyst
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
-        return AdditionalInitialization.withCapabilities(Stability.EXPERIMENTAL);
+        return AdditionalInitialization.withCapabilities(Stability.DEFAULT);
     }
 }

--- a/wildfly-mcp/subsystem/src/test/resources/org/wildfly/extension/mcp/mcp-1.0.xml
+++ b/wildfly-mcp/subsystem/src/test/resources/org/wildfly/extension/mcp/mcp-1.0.xml
@@ -3,6 +3,6 @@
 ~ SPDX-License-Identifier: Apache-2.0
 -->
 
-<subsystem xmlns="urn:jboss:domain:mcp:experimental:1.0">
+<subsystem xmlns="urn:jboss:domain:mcp:1.0">
     <mcp-server name="server" sse-path="sse" messages-path="messages" streamable-path="stream"/>
 </subsystem>

--- a/wildfly-mcp/subsystem/src/test/resources/org/wildfly/extension/mcp/mcp-1.0.xml
+++ b/wildfly-mcp/subsystem/src/test/resources/org/wildfly/extension/mcp/mcp-1.0.xml
@@ -4,5 +4,5 @@
 -->
 
 <subsystem xmlns="urn:jboss:domain:mcp:1.0">
-    <mcp-server name="server" sse-path="sse" messages-path="messages" streamable-path="stream"/>
+    <mcp-server name="server" />
 </subsystem>


### PR DESCRIPTION
Promote the MCP subsystem, mcp-server layer, and required packages
from experimental to default stability level. The XML namespace
changes from urn:jboss:domain:mcp:experimental:1.0 to
urn:jboss:domain:mcp:1.0. The testsuite/mcp provisions and runs
WildFly at default stability.

Fixes #277