### PR TITLE
chore(deps): Upgrade WildFly to 40.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.release>17</maven.compiler.release>
 
-        <version.org.wildfly>39.0.1.Final</version.org.wildfly>
+        <version.org.wildfly>40.0.0.Final</version.org.wildfly>
         <version.org.wildfly.core>32.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>8.1.0.Final</version.org.wildfly.galleon-plugins>

--- a/wildfly-mcp/injection/pom.xml
+++ b/wildfly-mcp/injection/pom.xml
@@ -22,20 +22,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-weld-common</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>

--- a/wildfly-mcp/subsystem/pom.xml
+++ b/wildfly-mcp/subsystem/pom.xml
@@ -24,11 +24,6 @@
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem</artifactId>
         </dependency>
-        <!-- CDI -->
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
@@ -36,10 +31,6 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.enterprise.concurrent</groupId>
-            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>
@@ -101,16 +92,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-elytron-oidc-client-subsystem</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly</groupId>
             <artifactId>wildfly-web-common</artifactId>
         </dependency>
         <dependency>
@@ -167,16 +148,6 @@
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.undertow</groupId>
-            <artifactId>undertow-websockets-jsr</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Remove unused undertow-servlet and undertow-websockets-jsr dependencies from wildfly-mcp subsystem. These artifacts moved to the io.undertow.ee groupId in Undertow 2.4.x (used by WildFly 40), and the code only uses classes from undertow-core.

Remove other unused compile dependencies from wildfly-mcp modules:
- jakarta.annotation-api from subsystem and injection
- jakarta.enterprise.concurrent-api from subsystem
- wildfly-elytron-oidc-client-subsystem from subsystem
- wildfly-weld-common from injection