### PR TITLE
fix(mcp): Add cdi layer dependency to mcp-server layer

### DIFF
--- a/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mcp-server/layer-spec.xml
@@ -12,6 +12,7 @@
         <prop name="org.wildfly.rule.annotations" value="org.mcp_java.server.*"/>
     </props>
     <dependencies>
+        <layer name="cdi"/>
         <layer name="ee-concurrency"/>
     </dependencies>
     <feature spec="subsystem.mcp">


### PR DESCRIPTION
The MCP subsystem requires CDI to discover and register @Tool, @Prompt, and @Resource beans via the MCPPortableExtension. Without this explicit dependency, provisioning with only the mcp-server layer would not include CDI, causing silent failure of bean discovery.