### PR TITLE
Remove unnecessary assertj-core bundling in MCP test WARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <version.org.reactivestreams.reactive-streams>1.0.4</version.org.reactivestreams.reactive-streams>
 
         <version.junit>5.11.4</version.junit>
-        <version.assertj>3.26.3</version.assertj>
+        <version.assertj>3.27.7</version.assertj>
 
         <!-- Nexus deployment settings -->
         <nexus.staging.tag>ai-feature-pack-${project.version}</nexus.staging.tag>

--- a/testsuite/mcp/pom.xml
+++ b/testsuite/mcp/pom.xml
@@ -133,31 +133,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- Maven Dependency Plugin - Copy test libraries for Arquillian deployments -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-test-libs</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.assertj</groupId>
-                                    <artifactId>assertj-core</artifactId>
-                                    <version>${version.assertj}</version>
-                                    <outputDirectory>${project.build.directory}/test-libs</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/MCPPaginationIntegrationTestCase.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/MCPPaginationIntegrationTestCase.java
@@ -7,7 +7,6 @@ package org.wildfly.ai.test.mcp;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringReader;
@@ -83,7 +82,6 @@ public class MCPPaginationIntegrationTestCase {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "mcp-pagination-test.war")
                 .addClass(TestMCPPaginationFixtures.class)
-                .addAsLibraries(new File("target/test-libs/assertj-core-3.26.3.jar"))
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/MCPServerIntegrationTestCase.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/MCPServerIntegrationTestCase.java
@@ -7,7 +7,6 @@ package org.wildfly.ai.test.mcp;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringReader;
@@ -84,7 +83,6 @@ public class MCPServerIntegrationTestCase {
                 .addClass(TestMCPElicitationTool.class)
                 .addClass(TestMCPProgressTool.class)
                 .addClass(TestMCPCompletion.class)
-                .addAsLibraries(new File("target/test-libs/assertj-core-3.26.3.jar"))
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         return archive;
     }


### PR DESCRIPTION
## Summary
- Remove hardcoded `addAsLibraries(new File("target/test-libs/assertj-core-3.26.3.jar"))` from `MCPServerIntegrationTestCase` and `MCPPaginationIntegrationTestCase`
- Remove the `maven-dependency-plugin` copy execution and unused `java.io.File` imports
- The MCP integration tests run client-side (`@RunAsClient`, `testable = false`), so assertj-core only needs to be on the test classpath — not bundled in the WAR

This fixes the test failure introduced by the assertj-core bump from 3.26.3 to 3.27.7 (commit 8fe0bc4), where the hardcoded jar filename no longer matched the actual file on disk.

## Test plan
- [x] `mvn test -pl testsuite/mcp` — all 46 tests pass (38 + 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)