### PR TITLE
refactor(mcp): use Optional for schema generator fields in MCPFeatureMetadata

### DIFF
--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPFeatureMetadata.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPFeatureMetadata.java
@@ -5,6 +5,7 @@
 package org.wildfly.extension.mcp.injection.tool;
 
 import java.util.List;
+import java.util.Optional;
 import org.mcp_java.model.tool.ToolAnnotations;
 
 /**
@@ -19,22 +20,16 @@ import org.mcp_java.model.tool.ToolAnnotations;
  * @param method metadata about the Java method that implements this feature
  * @param toolAnnotations optional MCP tool annotations (title, hints) for tools; null for non-tool features
  * @param structuredContent whether the tool returns structured content that should include an outputSchema
- * @param inputSchemaGenerator optional class name of a {@link ToolSchemaGenerator} CDI bean for input schema; empty string if not provided
- * @param outputSchemaGenerator optional class name of a {@link ToolSchemaGenerator} CDI bean for output schema; empty string if not provided
- * @param outputSchemaFrom optional class name to generate output schema from; empty string if not provided
+ * @param inputSchemaGenerator optional class name of a {@link ToolSchemaGenerator} CDI bean for input schema
+ * @param outputSchemaGenerator optional class name of a {@link ToolSchemaGenerator} CDI bean for output schema
+ * @param outputSchemaFrom optional class name to generate output schema from
  */
 public record MCPFeatureMetadata(Kind kind, String name, MethodMetadata method, ToolAnnotations toolAnnotations,
-        boolean structuredContent, String inputSchemaGenerator, String outputSchemaGenerator, String outputSchemaFrom) {
-
-    public MCPFeatureMetadata {
-        inputSchemaGenerator = inputSchemaGenerator != null ? inputSchemaGenerator : "";
-        outputSchemaGenerator = outputSchemaGenerator != null ? outputSchemaGenerator : "";
-        outputSchemaFrom = outputSchemaFrom != null ? outputSchemaFrom : "";
-    }
+        boolean structuredContent, Optional<String> inputSchemaGenerator, Optional<String> outputSchemaGenerator, Optional<String> outputSchemaFrom) {
 
     /** Convenience constructor for non-tool kinds (prompts, resources, completions) that don't carry ToolAnnotations. */
     public MCPFeatureMetadata(Kind kind, String name, MethodMetadata method) {
-        this(kind, name, method, null, false, "", "", "");
+        this(kind, name, method, null, false, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     /** Returns the human-readable description of the feature, taken from the method metadata. */

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPLogger.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPLogger.java
@@ -148,5 +148,17 @@ public interface MCPLogger extends BasicLogger {
     String resourceUriNotDefined();
 
     @Message(id = 35, value = "No resource template matches URI: %s")
-    String noMatchingResourceTempate(String resourceUri);
+    String noMatchingResourceTemplate(String resourceUri);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 36, value = "Skipping tool '%s' from listing (schema generation failed): %s")
+    void errorSkippingToolFromListing(String toolName, String reason);
+
+    @LogMessage(level = WARN)
+    @Message(id = 37, value = "Schema generator class '%s' does not implement ToolSchemaGenerator")
+    void warnSchemaGeneratorInvalidType(String className);
+
+    @LogMessage(level = WARN)
+    @Message(id = 38, value = "Failed to resolve schema generator '%s'")
+    void warnFailedToResolveSchemaGenerator(@Cause Throwable cause, String className);
 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/ConnectionManager.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/ConnectionManager.java
@@ -65,6 +65,18 @@ public class ConnectionManager {
 
     /**
      * Removes and closes the connection with the given session ID.
+     * <p>
+     * I/O design: {@code connection.close()} runs outside any {@code synchronized} block intentionally.
+     * Holding the lock during I/O would block {@code cleanup}, {@code add}, and {@code get} on slow
+     * or blocking transports. The connection is removed from the map <em>before</em> being closed, so
+     * concurrent callers cannot double-close the same connection.
+     * </p>
+     * <p>
+     * Trade-off: {@link #broadcastThenShutdown(JsonObject...)} cannot guarantee that zero connections
+     * are closed between its two synchronized phases (broadcast and teardown). A concurrent
+     * {@code cleanup} firing in that window may close a connection after its notification was sent.
+     * This race is benign on a shutdown path.
+     * </p>
      *
      * @param id the session ID of the connection to remove
      * @return {@code true} if the connection existed and was successfully closed; {@code false} otherwise

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/Messages.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/Messages.java
@@ -37,6 +37,12 @@ public class Messages {
      * for JSON numbers, a double-quoted string for JSON strings, or {@code null} for absent ids.
      * This method re-parses accordingly so the output preserves the original type.
      * </p>
+     * <p>
+     * <b>Limitation:</b> Only integer ({@code long}) and string ids are fully supported. Float ids
+     * such as {@code 1.5} fail {@code Long.parseLong} and are not enclosed in double-quotes, so they
+     * fall through to the else branch and are written back as JSON strings, silently changing their
+     * type. The MCP spec uses integer and string ids in practice, so this is an accepted limitation.
+     * </p>
      */
     private static void addId(JsonObjectBuilder response, String id) {
         if (id == null) {

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPServerDependencyProcessor.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/deployment/MCPServerDependencyProcessor.java
@@ -23,6 +23,7 @@ import static org.wildfly.extension.mcp.injection.MCPFieldNames.URI_TEMPLATE;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -197,7 +198,10 @@ public class MCPServerDependencyProcessor implements DeploymentUnitProcessor {
                             arguments,
                             info.declaringClass().toString(),
                             annotation.target().asMethod().returnType().name().toString()),
-                    toolAnnotations, structuredContent, inputSchemaGenerator, outputSchemaGenerator, outputSchemaFrom
+                    toolAnnotations, structuredContent,
+                    Optional.ofNullable(inputSchemaGenerator).filter(s -> !s.isEmpty()),
+                    Optional.ofNullable(outputSchemaGenerator).filter(s -> !s.isEmpty()),
+                    Optional.ofNullable(outputSchemaFrom).filter(s -> !s.isEmpty())
             );
             registry.addTool(name, metadata);
         }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceTemplateMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceTemplateMessageHandler.java
@@ -113,7 +113,7 @@ public class ResourceTemplateMessageHandler {
 
         final MCPFeatureMetadata metadata = registry.findResourceTemplateByUri(resourceUri);
         if (metadata == null) {
-            responder.sendError(id, INVALID_PARAMS, ROOT_LOGGER.noMatchingResourceTempate(resourceUri));
+            responder.sendError(id, INVALID_PARAMS, ROOT_LOGGER.noMatchingResourceTemplate(resourceUri));
             return;
         }
         Map<String, JsonValue> args = extractTemplateArguments(metadata.method().uri(), resourceUri);

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -131,7 +132,7 @@ public class ToolMessageHandler {
                 tools.add(toolJsonCache.computeIfAbsent(toolMetadata.name(), k -> buildToolJson(toolMetadata)));
             } catch (RuntimeException e) {
                 failedToolNames.add(toolMetadata.name());
-                ROOT_LOGGER.errorf("Skipping tool %s from listing (schema generation failed): %s", toolMetadata.name(), e.getMessage());
+                ROOT_LOGGER.errorSkippingToolFromListing(toolMetadata.name(), e.getMessage());
             }
         }
         JsonObjectBuilder resultBuilder = Json.createObjectBuilder().add(TOOLS, tools);
@@ -152,8 +153,8 @@ public class ToolMessageHandler {
     }
 
     private void addInputSchema(JsonObjectBuilder tool, MCPFeatureMetadata toolMetadata) {
-        if (!toolMetadata.inputSchemaGenerator().isEmpty()) {
-            JsonObject generated = resolveGeneratedSchema(toolMetadata.inputSchemaGenerator());
+        if (toolMetadata.inputSchemaGenerator().isPresent()) {
+            JsonObject generated = resolveGeneratedSchema(toolMetadata.inputSchemaGenerator().get());
             if (generated != null) {
                 tool.add(INPUT_SCHEMA, generated);
                 return;
@@ -209,16 +210,16 @@ public class ToolMessageHandler {
     }
 
     private void addOutputSchema(JsonObjectBuilder tool, MCPFeatureMetadata toolMetadata) {
-        if (!toolMetadata.outputSchemaGenerator().isEmpty()) {
-            JsonObject generated = resolveGeneratedSchema(toolMetadata.outputSchemaGenerator());
+        if (toolMetadata.outputSchemaGenerator().isPresent()) {
+            JsonObject generated = resolveGeneratedSchema(toolMetadata.outputSchemaGenerator().get());
             if (generated != null) {
                 tool.add(OUTPUT_SCHEMA, generated);
                 return;
             }
         }
         if (toolMetadata.structuredContent()) {
-            String outputSchemaType = !toolMetadata.outputSchemaFrom().isEmpty()
-                    ? toolMetadata.outputSchemaFrom()
+            String outputSchemaType = toolMetadata.outputSchemaFrom().isPresent()
+                    ? toolMetadata.outputSchemaFrom().get()
                     : toolMetadata.method().returnType();
             JsonObject outputSchema = generateOutputSchema(outputSchemaType);
             if (outputSchema != null) {
@@ -237,7 +238,7 @@ public class ToolMessageHandler {
         try {
             Class<?> generatorClass = classLoader.loadClass(generatorClassName);
             if (!ToolSchemaGenerator.class.isAssignableFrom(generatorClass)) {
-                ROOT_LOGGER.warnf("Schema generator class %s does not implement ToolSchemaGenerator", generatorClassName);
+                ROOT_LOGGER.warnSchemaGeneratorInvalidType(generatorClassName);
                 return null;
             }
             String schemaJson = invokeSchemaGenerator(generatorClass);
@@ -245,7 +246,7 @@ public class ToolMessageHandler {
                 return reader.readObject();
             }
         } catch (Exception e) {
-            ROOT_LOGGER.warnf("Failed to resolve schema generator %s: %s", generatorClassName, e.getMessage());
+            ROOT_LOGGER.warnFailedToResolveSchemaGenerator(e, generatorClassName);
             return null;
         }
     }

--- a/wildfly-mcp/subsystem/src/test/java/org/wildfly/extension/mcp/api/MessagesTestCase.java
+++ b/wildfly-mcp/subsystem/src/test/java/org/wildfly/extension/mcp/api/MessagesTestCase.java
@@ -64,4 +64,14 @@ public class MessagesTestCase {
         assertEquals(JsonValue.ValueType.STRING, error.get("id").getValueType());
         assertEquals("req-abc", error.getString("id"));
     }
+
+    @Test
+    public void testFloatIdWrittenAsString() {
+        // Float ids (e.g. JSON number 1.5) are not supported. Long.parseLong("1.5") throws, the value
+        // is not a quoted string, so it falls through and is written as a JSON string — changing type.
+        // This documents the known limitation; the MCP spec uses integer and string ids in practice.
+        JsonObject result = Messages.newResult("1.5", Json.createObjectBuilder());
+        assertEquals(JsonValue.ValueType.STRING, result.get("id").getValueType());
+        assertEquals("1.5", result.getString("id"));
+    }
 }

--- a/wildfly-mcp/subsystem/src/test/java/org/wildfly/extension/mcp/server/ToolAnnotationsTestCase.java
+++ b/wildfly-mcp/subsystem/src/test/java/org/wildfly/extension/mcp/server/ToolAnnotationsTestCase.java
@@ -15,6 +15,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 import org.mcp_java.model.tool.ToolAnnotations;
 import org.wildfly.extension.mcp.api.ConnectionManager;
@@ -196,7 +197,7 @@ public class ToolAnnotationsTestCase {
                 new MethodMetadata("method", "Tool with unloadable return type", null, null,
                         List.of(),
                         "org.test.TestTool", "org.nonexistent.NoSuchType"),
-                null, true, "", "", ""));
+                null, true, Optional.empty(), Optional.empty(), Optional.empty()));
 
         ctx.handler().handle(jsonRpcRequest(3, "tools/list"), ctx.connection(), ctx.responder());
         assertTrue(ctx.responder().hasResult());
@@ -231,7 +232,7 @@ public class ToolAnnotationsTestCase {
                         List.of(new ArgumentMetadata("ignored", "This is ignored", true, String.class)),
                         "org.test.TestTool", "java.lang.String"),
                 null, false,
-                TestInputSchemaGenerator.class.getName(), "", ""));
+                Optional.of(TestInputSchemaGenerator.class.getName()), Optional.empty(), Optional.empty()));
 
         ctx.handler().handle(jsonRpcRequest(3, "tools/list"), ctx.connection(), ctx.responder());
         assertTrue(ctx.responder().hasResult());
@@ -252,8 +253,8 @@ public class ToolAnnotationsTestCase {
                 MCPFeatureMetadata.Kind.TOOL, "gen-out-tool",
                 new MethodMetadata("genOutTool", "Tool with output generator", null, null,
                         List.of(), "org.test.TestTool", "java.lang.String"),
-                null, true, "",
-                TestOutputSchemaGenerator.class.getName(), ""));
+                null, true, Optional.empty(),
+                Optional.of(TestOutputSchemaGenerator.class.getName()), Optional.empty()));
 
         ctx.handler().handle(jsonRpcRequest(3, "tools/list"), ctx.connection(), ctx.responder());
         assertTrue(ctx.responder().hasResult());
@@ -275,7 +276,7 @@ public class ToolAnnotationsTestCase {
                         List.of(new ArgumentMetadata("name", "A name", true, String.class)),
                         "org.test.TestTool", "java.lang.String"),
                 null, false,
-                "org.nonexistent.NoSuchGenerator", "", ""));
+                Optional.of("org.nonexistent.NoSuchGenerator"), Optional.empty(), Optional.empty()));
 
         ctx.handler().handle(jsonRpcRequest(3, "tools/list"), ctx.connection(), ctx.responder());
         assertTrue(ctx.responder().hasResult());
@@ -297,7 +298,7 @@ public class ToolAnnotationsTestCase {
                         List.of(new ArgumentMetadata("name", "A name", true, String.class)),
                         "org.test.TestTool", "java.lang.String"),
                 null, false,
-                "java.lang.String", "", ""));
+                Optional.of("java.lang.String"), Optional.empty(), Optional.empty()));
 
         ctx.handler().handle(jsonRpcRequest(3, "tools/list"), ctx.connection(), ctx.responder());
         assertTrue(ctx.responder().hasResult());
@@ -326,7 +327,7 @@ public class ToolAnnotationsTestCase {
                 new MethodMetadata("testTool", "A test tool", null, null,
                         List.of(new ArgumentMetadata("input", "Test input", true, String.class)),
                         "org.test.TestTool", "java.lang.String"),
-                annotations, structuredContent, "", "", ""));
+                annotations, structuredContent, Optional.empty(), Optional.empty(), Optional.empty()));
 
         ctx.handler().handle(jsonRpcRequest(3, "tools/list"), ctx.connection(), ctx.responder());
         assertTrue(ctx.responder().hasResult());


### PR DESCRIPTION
Replace empty-string sentinels with Optional<String> for inputSchemaGenerator, outputSchemaGenerator, and outputSchemaFrom. Add structured logger methods for schema-related warnings/errors and fix noMatchingResourceTemplate typo.