### PR TITLE
chore: Upgrade LangChain4J to 1.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,11 @@
         <version.com.squareup.okio-jvm>3.6.0</version.com.squareup.okio-jvm>
         <version.com.squareup.retrofit2>2.11.0</version.com.squareup.retrofit2>
         <version.commons-compress>1.27.1</version.commons-compress>
-        <version.dev.langchain4j>1.15.0-beta25</version.dev.langchain4j>
+        <version.dev.langchain4j>1.15.1-beta25</version.dev.langchain4j>
         <version.dev.langchain4j.cdi>1.3.0</version.dev.langchain4j.cdi>
         <version.dev.langchain4j.community>1.15.0-beta25</version.dev.langchain4j.community>
-        <version.dev.langchain4j.core>1.15.0</version.dev.langchain4j.core>
-        <version.dev.langchain4j.embeddings>1.15.0-beta25</version.dev.langchain4j.embeddings>
+        <version.dev.langchain4j.core>1.15.1</version.dev.langchain4j.core>
+        <version.dev.langchain4j.embeddings>1.15.1-beta25</version.dev.langchain4j.embeddings>
         <version.io.projectreactor.netty>1.2.10</version.io.projectreactor.netty>
         <version.io.projectreactor.reactor-core>3.7.14</version.io.projectreactor.reactor-core>
         <version.io.weaviate.client>5.3.0</version.io.weaviate.client>


### PR DESCRIPTION
Changes in pom.xml:
- version.dev.langchain4j: 1.15.0-beta25 → 1.15.1-beta25
- version.dev.langchain4j.core: 1.15.0 → 1.15.1
- version.dev.langchain4j.embeddings: 1.15.0-beta25 → 1.15.1-beta25