### PR TITLE
Inject the ElicitationSender with CDI

### DIFF
--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/ElicitationIntegrationTestCase.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/ElicitationIntegrationTestCase.java
@@ -11,6 +11,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -21,6 +22,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Integration tests for MCP elicitation (form mode and URL mode).
@@ -31,6 +34,9 @@ public class ElicitationIntegrationTestCase extends AbstractMCPIntegrationTestCa
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "mcp-elicitation.war")
                 .addClass(TestMCPElicitationTool.class)
+                .addClass(TestMCPElicitationInjectedTool.class)
+                .addClass(TestMCPElicitationInjectedPrompt.class)
+                .addClass(TestMCPElicitationInjectedResourceTemplate.class)
                 .addClass(TestThirdPartyApplication.class)
                 .addClass(TestThirdPartyApplication.TestCallbackEndpoint.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
@@ -38,35 +44,40 @@ public class ElicitationIntegrationTestCase extends AbstractMCPIntegrationTestCa
 
     // ==================== Form Mode Elicitation ====================
 
-    @Test
-    public void testElicitationToolListedWithoutSenderParam() throws Exception {
+    static Stream<String> elicitationToolNames() {
+        return Stream.of("greet-with-name", "greet-with-name-injected");
+    }
+
+    @ParameterizedTest
+    @MethodSource("elicitationToolNames")
+    public void testElicitationToolListedWithoutSenderInSchema(String toolName) throws Exception {
         String response = sendAndReceive("tools/list", null);
-        assertThat(response).as("Should list the greet-with-name tool").contains("greet-with-name");
-        assertThat(response).as("ElicitationSender must not appear in inputSchema").doesNotContain("ElicitationSender");
+        assertThat(response).as("Should list the %s tool", toolName).contains(toolName);
 
         JsonObject json = Json.createReader(new StringReader(response)).readObject();
         JsonArray tools = json.getJsonObject("result").getJsonArray("tools");
         JsonObject greetTool = null;
         for (int i = 0; i < tools.size(); i++) {
-            if ("greet-with-name".equals(tools.getJsonObject(i).getString("name"))) {
+            if (toolName.equals(tools.getJsonObject(i).getString("name"))) {
                 greetTool = tools.getJsonObject(i);
                 break;
             }
         }
-        assertThat(greetTool).as("greet-with-name tool should be present").isNotNull();
+        assertThat(greetTool).as("%s tool should be present", toolName).isNotNull();
         JsonArray required = greetTool.getJsonObject("inputSchema").getJsonArray("required");
-        assertThat(required).as("greet-with-name should have empty required array").isEmpty();
+        assertThat(required).as("%s should have empty required array", toolName).isEmpty();
     }
 
-    @Test
-    public void testElicitationAcceptRoundTrip() throws Exception {
+    @ParameterizedTest
+    @MethodSource("elicitationToolNames")
+    public void testElicitationAcceptRoundTrip(String toolName) throws Exception {
         long toolCallId = nextId.getAndIncrement();
         CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
         pendingResponses.put(toolCallId, toolResultFuture);
 
         String toolCallMessage = """
-                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"greet-with-name","arguments":{}}}"""
-                .formatted(toolCallId);
+                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"%s","arguments":{}}}"""
+                .formatted(toolCallId, toolName);
 
         postToStreamable(toolCallMessage);
 
@@ -96,15 +107,16 @@ public class ElicitationIntegrationTestCase extends AbstractMCPIntegrationTestCa
         assertThat(content.getJsonObject(0).getString("text")).as("Should greet by name").contains("Hello, WildFly!");
     }
 
-    @Test
-    public void testElicitationDeclineRoundTrip() throws Exception {
+    @ParameterizedTest
+    @MethodSource("elicitationToolNames")
+    public void testElicitationDeclineRoundTrip(String toolName) throws Exception {
         long toolCallId = nextId.getAndIncrement();
         CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
         pendingResponses.put(toolCallId, toolResultFuture);
 
         String toolCallMessage = """
-                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"greet-with-name","arguments":{}}}"""
-                .formatted(toolCallId);
+                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"%s","arguments":{}}}"""
+                .formatted(toolCallId, toolName);
 
         postToStreamable(toolCallMessage);
 
@@ -256,5 +268,143 @@ public class ElicitationIntegrationTestCase extends AbstractMCPIntegrationTestCa
         JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
         assertThat(content.getJsonObject(0).getString("text")).as("Should indicate declined")
                 .contains("Authentication declined");
+    }
+
+    // ==================== CDI-Injected ElicitationSender in Prompts ====================
+
+    @Test
+    public void testInjectedElicitationPromptAcceptRoundTrip() throws Exception {
+        long promptCallId = nextId.getAndIncrement();
+        CompletableFuture<String> promptResultFuture = new CompletableFuture<>();
+        pendingResponses.put(promptCallId, promptResultFuture);
+
+        String promptCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"prompts/get","params":{"name":"confirm-greeting","arguments":{"name":"WildFly"}}}"""
+                .formatted(promptCallId);
+
+        postToStreamable(promptCallMessage);
+
+        String elicitationJson = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(elicitationJson).as("Should receive elicitation/create request from prompt").isNotNull();
+        assertThat(elicitationJson).as("Should be an elicitation/create request").contains("elicitation/create");
+        assertThat(elicitationJson).as("Should contain the confirmation message").contains("Confirm greeting for WildFly");
+
+        JsonObject elicitationMessage = Json.createReader(new StringReader(elicitationJson)).readObject();
+        long elicitationId = elicitationMessage.getJsonNumber("id").longValue();
+
+        String clientResponse = """
+                {"jsonrpc":"2.0","id":%d,"result":{"action":"accept","content":{"confirm":true}}}"""
+                .formatted(elicitationId);
+        postToStreamable(clientResponse);
+
+        String promptResult = promptResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(promptResult).as("Should receive prompt result after elicitation").isNotNull();
+
+        JsonObject resultJson = Json.createReader(new StringReader(promptResult)).readObject();
+        JsonArray messages = resultJson.getJsonObject("result").getJsonArray("messages");
+        assertThat(messages).as("Should contain messages").isNotNull();
+        String text = messages.getJsonObject(0).getJsonObject("content").getString("text");
+        assertThat(text).as("Should contain confirmed greeting").contains("Confirmed greeting for WildFly");
+    }
+
+    @Test
+    public void testInjectedElicitationPromptDeclineRoundTrip() throws Exception {
+        long promptCallId = nextId.getAndIncrement();
+        CompletableFuture<String> promptResultFuture = new CompletableFuture<>();
+        pendingResponses.put(promptCallId, promptResultFuture);
+
+        String promptCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"prompts/get","params":{"name":"confirm-greeting","arguments":{"name":"WildFly"}}}"""
+                .formatted(promptCallId);
+
+        postToStreamable(promptCallMessage);
+
+        String elicitationJson = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(elicitationJson).as("Should receive elicitation/create request").isNotNull();
+
+        JsonObject elicitationMessage = Json.createReader(new StringReader(elicitationJson)).readObject();
+        long elicitationId = elicitationMessage.getJsonNumber("id").longValue();
+
+        String clientResponse = """
+                {"jsonrpc":"2.0","id":%d,"result":{"action":"decline"}}"""
+                .formatted(elicitationId);
+        postToStreamable(clientResponse);
+
+        String promptResult = promptResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(promptResult).as("Should receive prompt result after decline").isNotNull();
+
+        JsonObject resultJson = Json.createReader(new StringReader(promptResult)).readObject();
+        JsonArray messages = resultJson.getJsonObject("result").getJsonArray("messages");
+        String text = messages.getJsonObject(0).getJsonObject("content").getString("text");
+        assertThat(text).as("Should indicate not confirmed").contains("Greeting not confirmed");
+    }
+
+    // ==================== CDI-Injected ElicitationSender in Resource Templates ====================
+
+    @Test
+    public void testInjectedElicitationResourceTemplateAcceptRoundTrip() throws Exception {
+        long readCallId = nextId.getAndIncrement();
+        CompletableFuture<String> readResultFuture = new CompletableFuture<>();
+        pendingResponses.put(readCallId, readResultFuture);
+
+        String readCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"resources/read","params":{"uri":"test://secret/42"}}"""
+                .formatted(readCallId);
+
+        postToStreamable(readCallMessage);
+
+        String elicitationJson = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(elicitationJson).as("Should receive elicitation/create request from resource template").isNotNull();
+        assertThat(elicitationJson).as("Should be an elicitation/create request").contains("elicitation/create");
+        assertThat(elicitationJson).as("Should contain the confirmation message").contains("Confirm access to secret 42");
+
+        JsonObject elicitationMessage = Json.createReader(new StringReader(elicitationJson)).readObject();
+        long elicitationId = elicitationMessage.getJsonNumber("id").longValue();
+
+        String clientResponse = """
+                {"jsonrpc":"2.0","id":%d,"result":{"action":"accept","content":{"confirm":true}}}"""
+                .formatted(elicitationId);
+        postToStreamable(clientResponse);
+
+        String readResult = readResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(readResult).as("Should receive resource result after elicitation").isNotNull();
+
+        JsonObject resultJson = Json.createReader(new StringReader(readResult)).readObject();
+        JsonArray contents = resultJson.getJsonObject("result").getJsonArray("contents");
+        assertThat(contents).as("Should contain contents").isNotNull();
+        String text = contents.getJsonObject(0).getString("text");
+        assertThat(text).as("Should contain the secret value").isEqualTo("secret-value-for-42");
+    }
+
+    @Test
+    public void testInjectedElicitationResourceTemplateDeclineRoundTrip() throws Exception {
+        long readCallId = nextId.getAndIncrement();
+        CompletableFuture<String> readResultFuture = new CompletableFuture<>();
+        pendingResponses.put(readCallId, readResultFuture);
+
+        String readCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"resources/read","params":{"uri":"test://secret/42"}}"""
+                .formatted(readCallId);
+
+        postToStreamable(readCallMessage);
+
+        String elicitationJson = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(elicitationJson).as("Should receive elicitation/create request").isNotNull();
+
+        JsonObject elicitationMessage = Json.createReader(new StringReader(elicitationJson)).readObject();
+        long elicitationId = elicitationMessage.getJsonNumber("id").longValue();
+
+        String clientResponse = """
+                {"jsonrpc":"2.0","id":%d,"result":{"action":"decline"}}"""
+                .formatted(elicitationId);
+        postToStreamable(clientResponse);
+
+        String readResult = readResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(readResult).as("Should receive resource result after decline").isNotNull();
+
+        JsonObject resultJson = Json.createReader(new StringReader(readResult)).readObject();
+        JsonArray contents = resultJson.getJsonObject("result").getJsonArray("contents");
+        String text = contents.getJsonObject(0).getString("text");
+        assertThat(text).as("Should deny access").isEqualTo("access-denied");
     }
 }

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationInjectedPrompt.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationInjectedPrompt.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.test.mcp;
+
+import jakarta.inject.Inject;
+import org.mcpjava.server.content.TextContent;
+import org.mcpjava.server.prompts.Prompt;
+import org.mcpjava.server.prompts.PromptArg;
+import org.mcpjava.server.prompts.PromptResponse;
+import org.wildfly.mcp.api.elicitation.Elicitation;
+import org.wildfly.mcp.api.elicitation.ElicitationSender;
+
+import static org.mcpjava.server.Role.USER;
+
+public class TestMCPElicitationInjectedPrompt {
+
+    @Inject
+    ElicitationSender elicitationSender;
+
+    @Prompt(name = "confirm-greeting", description = "Asks user to confirm before generating a greeting")
+    PromptResponse confirmGreeting(@PromptArg(description = "Name to greet") String name) throws Exception {
+        if (!elicitationSender.isFormSupported()) {
+            return PromptResponse.of(USER, TextContent.of("Hello, " + name + "!"));
+        }
+        Elicitation.FormBuilder form = Elicitation.formBuilder("Confirm greeting for " + name + "?")
+                .timeout(30_000);
+        form.addBoolean("confirm");
+        Elicitation.Response response = elicitationSender.send(form.build());
+        if (response.isAccepted() && response.getBoolean("confirm").orElse(false)) {
+            return PromptResponse.of(USER, TextContent.of("Confirmed greeting for " + name));
+        }
+        return PromptResponse.of(USER, TextContent.of("Greeting not confirmed"));
+    }
+}

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationInjectedResourceTemplate.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationInjectedResourceTemplate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.test.mcp;
+
+import jakarta.inject.Inject;
+
+import org.mcpjava.server.resources.ResourceContents;
+import org.mcpjava.server.resources.ResourceTemplate;
+import org.mcpjava.server.resources.ResourceTemplateArg;
+import org.mcpjava.server.resources.TextResourceContents;
+import org.wildfly.mcp.api.elicitation.Elicitation;
+import org.wildfly.mcp.api.elicitation.ElicitationSender;
+
+public class TestMCPElicitationInjectedResourceTemplate {
+
+    @Inject
+    ElicitationSender elicitationSender;
+
+    @ResourceTemplate(uriTemplate = "test://secret/{id}", mimeType = "text/plain", name = "secret-data")
+    ResourceContents secretData(@ResourceTemplateArg(name = "id") String id) throws Exception {
+        if (!elicitationSender.isFormSupported()) {
+            return TextResourceContents.of("test://secret/" + id, "access-denied");
+        }
+        Elicitation.FormBuilder form = Elicitation.formBuilder("Confirm access to secret " + id + "?")
+                .timeout(30_000);
+        form.addBoolean("confirm");
+        Elicitation.Response response = elicitationSender.send(form.build());
+        if (response.isAccepted() && response.getBoolean("confirm").orElse(false)) {
+            return TextResourceContents.of("test://secret/" + id, "secret-value-for-" + id);
+        }
+        return TextResourceContents.of("test://secret/" + id, "access-denied");
+    }
+}

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationInjectedTool.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationInjectedTool.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.test.mcp;
+
+import jakarta.inject.Inject;
+
+import org.mcpjava.server.tools.Tool;
+import org.wildfly.mcp.api.elicitation.Elicitation;
+import org.wildfly.mcp.api.elicitation.ElicitationSender;
+
+public class TestMCPElicitationInjectedTool {
+
+    @Inject
+    ElicitationSender elicitationSender;
+
+    @Tool(name = "greet-with-name-injected", description = "Asks the user for their name via CDI-injected elicitation and greets them")
+    String greetWithName() throws Exception {
+        if (!elicitationSender.isFormSupported()) {
+            return "Elicitation Form Mode not supported by client";
+        }
+        Elicitation.FormBuilder form = Elicitation.formBuilder("What is your name?")
+                .timeout(30_000);
+        form.addString("name")
+                .title("Your Name")
+                .description("Enter your first name");
+        Elicitation.Response response = elicitationSender.send(form.build());
+        return switch (response.action()) {
+            case ACCEPT -> "Hello, " + response.getString("name").orElse("stranger") + "!";
+            case CANCEL -> "Request was cancelled.";
+            case DECLINE -> "You declined to provide your name.";
+        };
+    }
+}

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationTool.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPElicitationTool.java
@@ -14,7 +14,6 @@ import org.mcpjava.server.tools.ToolArg;
 import org.wildfly.mcp.api.elicitation.BooleanProperty;
 import org.wildfly.mcp.api.elicitation.Elicitation;
 import org.wildfly.mcp.api.elicitation.ElicitationSender;
-import org.wildfly.mcp.api.elicitation.StringProperty;
 
 public class TestMCPElicitationTool {
 

--- a/wildfly-mcp/api/pom.xml
+++ b/wildfly-mcp/api/pom.xml
@@ -22,6 +22,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>

--- a/wildfly-mcp/api/src/main/java/org/wildfly/mcp/api/elicitation/ElicitationSender.java
+++ b/wildfly-mcp/api/src/main/java/org/wildfly/mcp/api/elicitation/ElicitationSender.java
@@ -5,23 +5,37 @@
 package org.wildfly.mcp.api.elicitation;
 
 /**
- * Injected into tool methods to allow pausing execution and requesting additional
- * user input from the MCP client.
+ * Allows MCP methods (tools, prompts, resources, resource templates) to pause
+ * execution and request additional user input from the MCP client.
  *
  * <p>The client must declare the {@code "elicitation"} capability during initialization.
- * Use {@link #isFormSupported()} or {@link #isUrlSupported()} ()}  to check before calling {@link #send}.</p>
+ * Use {@link #isFormSupported()} or {@link #isUrlSupported()} to check before calling {@link #send}.</p>
  *
- * <p>Example tool method signature:</p>
+ * <p>An {@code ElicitationSender} can be obtained either by CDI injection or as a
+ * tool method parameter:</p>
+ *
+ * <p><b>CDI injection (recommended):</b></p>
  * <pre>{@code
+ * @Inject
+ * ElicitationSender elicitationSender;
+ *
  * @Tool(description = "Creates a user account")
- * public String createAccount(String email, ElicitationSender elicitationSender) throws Exception {
- *     if (elicitation.isFormSupported()) {
+ * public String createAccount(String email) throws Exception {
+ *     if (elicitationSender.isFormSupported()) {
  *         Elicitation.FormBuilder form = Elicitation.formBuilder("Please confirm the account details");
  *         BooleanProperty confirm = form.addBoolean("confirm");
  *         Elicitation.Response response = elicitationSender.send(form.build());
  *         if (!response.isAccepted()) return "Cancelled";
  *     }
  *     // proceed...
+ * }
+ * }</pre>
+ *
+ * <p><b>Method parameter (only for tool invocation):</b></p>
+ * <pre>{@code
+ * @Tool(description = "Creates a user account")
+ * public String createAccount(String email, ElicitationSender elicitationSender) throws Exception {
+ *     // same usage as above
  * }
  * }</pre>
  */

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
@@ -6,6 +6,7 @@
 package org.wildfly.extension.mcp.injection;
 
 import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.WARN;
 
 import java.lang.invoke.MethodHandles;
 
@@ -24,4 +25,11 @@ public interface MCPLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 1, value = "Unexpected error")
     void unexpectedError(@Cause Throwable cause);
+
+    @LogMessage(level = WARN)
+    @Message(id = 2, value = "Vetoing user-defined ElicitationSender bean %s — ElicitationSender is provided by the MCP subsystem and must not be overridden by deployments")
+    void vetoedUserElicitationSender(String className);
+
+    @Message(id = 3, value = "ElicitationSender is not available outside of an MCP invocation context")
+    IllegalStateException elicitationSenderNotAvailable();
 }

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/elicitation/ElicitationSenderBean.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/elicitation/ElicitationSenderBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.mcp.injection.elicitation;
+
+import jakarta.enterprise.context.RequestScoped;
+
+import org.wildfly.mcp.api.elicitation.Elicitation;
+import org.wildfly.mcp.api.elicitation.ElicitationSender;
+
+import static org.wildfly.extension.mcp.injection.MCPLogger.ROOT_LOGGER;
+
+@RequestScoped
+public class ElicitationSenderBean implements ElicitationSender {
+
+    @Override
+    public Elicitation.Response send(Elicitation elicitation) throws Exception {
+        return delegate().send(elicitation);
+    }
+
+    @Override
+    public boolean isFormSupported() {
+        return delegate().isFormSupported();
+    }
+
+    @Override
+    public boolean isUrlSupported() {
+        return delegate().isUrlSupported();
+    }
+
+    @Override
+    public void notifyElicitationComplete(String elicitationId) {
+        delegate().notifyElicitationComplete(elicitationId);
+    }
+
+    private ElicitationSender delegate() {
+        ElicitationSender sender = ElicitationSenderHolder.get();
+        if (sender == null) {
+            throw ROOT_LOGGER.elicitationSenderNotAvailable();
+        }
+        return sender;
+    }
+}

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/elicitation/ElicitationSenderHolder.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/elicitation/ElicitationSenderHolder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.mcp.injection.elicitation;
+
+import org.wildfly.mcp.api.elicitation.ElicitationSender;
+
+public final class ElicitationSenderHolder {
+
+    private static final ThreadLocal<ElicitationSender> CURRENT = new ThreadLocal<>();
+
+    private ElicitationSenderHolder() {
+    }
+
+    public static void set(ElicitationSender sender) {
+        CURRENT.set(sender);
+    }
+
+    public static ElicitationSender get() {
+        return CURRENT.get();
+    }
+
+    public static void remove() {
+        CURRENT.remove();
+    }
+}

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPPortableExtension.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPPortableExtension.java
@@ -8,14 +8,18 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.literal.SingletonLiteral;
 import jakarta.enterprise.inject.spi.AfterTypeDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+import jakarta.enterprise.inject.spi.ProcessProducerField;
+import jakarta.enterprise.inject.spi.ProcessProducerMethod;
 import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
 import jakarta.enterprise.util.AnnotationLiteral;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.wildfly.extension.mcp.injection.MCPLogger;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
+import org.wildfly.extension.mcp.injection.elicitation.ElicitationSenderBean;
+import org.wildfly.mcp.api.elicitation.ElicitationSender;
 
 import static org.wildfly.extension.mcp.injection.MCPLogger.ROOT_LOGGER;
 
@@ -109,6 +113,28 @@ public class MCPPortableExtension implements Extension {
             }
             ROOT_LOGGER.debugf("%s should be discoverable by CDI", bean.getKey().getName());
         }
+        atd.addAnnotatedType(ElicitationSenderBean.class, "elicitation-sender-bean");
+    }
+
+    public <T extends ElicitationSender> void vetoUserElicitationSender(@Observes ProcessAnnotatedType<T> event) {
+        if (!ElicitationSenderBean.class.equals(event.getAnnotatedType().getJavaClass())) {
+            ROOT_LOGGER.vetoedUserElicitationSender(event.getAnnotatedType().getJavaClass().getName());
+            event.veto();
+        }
+    }
+
+    public <X> void vetoUserElicitationSenderProducer(@Observes ProcessProducerMethod<ElicitationSender, X> event) {
+        String name = event.getAnnotatedProducerMethod().getJavaMember().toGenericString();
+        ROOT_LOGGER.vetoedUserElicitationSender(name);
+        event.addDefinitionError(new IllegalStateException(
+                "Deployment must not produce ElicitationSender — it is provided by the MCP subsystem: " + name));
+    }
+
+    public <X> void vetoUserElicitationSenderField(@Observes ProcessProducerField<ElicitationSender, X> event) {
+        String name = event.getAnnotatedProducerField().getJavaMember().toGenericString();
+        ROOT_LOGGER.vetoedUserElicitationSender(name);
+        event.addDefinitionError(new IllegalStateException(
+                "Deployment must not produce ElicitationSender — it is provided by the MCP subsystem: " + name));
     }
 
     private void updateAnnotations(Map<Class<?>, Set<AnnotationLiteral>> beanClasses, Class<?> clazz, AnnotationLiteral... annotations) {

--- a/wildfly-mcp/injection/src/main/resources/META-INF/beans.xml
+++ b/wildfly-mcp/injection/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://java.sun.com/xml/ns/javaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-</beans>

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPServerUtils.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPServerUtils.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.undertow.util.HttpString;
+import jakarta.enterprise.context.control.RequestContextController;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
@@ -26,7 +28,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
+import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
+import org.wildfly.extension.mcp.injection.elicitation.ElicitationSenderHolder;
 import org.wildfly.extension.mcp.injection.tool.ArgumentMetadata;
 
 /**
@@ -104,6 +108,29 @@ final class MCPServerUtils {
             idx++;
         }
         return ret;
+    }
+
+    static void runWithCDIContext(MCPConnection connection, Responder responder, Runnable task) {
+        RequestContextController rcc = null;
+        try {
+            rcc = CDI.current().select(RequestContextController.class).get();
+            rcc.activate();
+        } catch (IllegalStateException e) {
+            rcc = null;
+        }
+        try {
+            ElicitationSenderHolder.set(new ElicitationSenderImpl(
+                    connection.pendingRequests(), responder, connection.initializeRequest()));
+            try {
+                task.run();
+            } finally {
+                ElicitationSenderHolder.remove();
+            }
+        } finally {
+            if (rcc != null) {
+                rcc.deactivate();
+            }
+        }
     }
 
     /**

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PromptMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PromptMessageHandler.java
@@ -28,6 +28,7 @@ import static org.wildfly.extension.mcp.server.MCPServerUtils.sendInvocationFail
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
+import static org.wildfly.extension.mcp.server.MCPServerUtils.runWithCDIContext;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -129,7 +130,7 @@ public class PromptMessageHandler {
         final ClassLoader prevCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            connection.task(executorService.submit(() -> {
+            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, () -> {
                 try {
                     MethodMetadata methodMetadata = metadata.method();
                     Class<?> clazz = classLoader.loadClass(methodMetadata.declaringClassName());
@@ -173,7 +174,7 @@ public class PromptMessageHandler {
                     ROOT_LOGGER.errorInvokingPrompt(ex, promptName);
                     sendInvocationFailureResult(id, ex, responder);
                 }
-            }));
+            })));
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(prevCL);
         }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceMessageHandler.java
@@ -30,6 +30,7 @@ import static org.wildfly.extension.mcp.server.MCPServerUtils.prepareArguments;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
+import static org.wildfly.extension.mcp.server.MCPServerUtils.runWithCDIContext;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -198,7 +199,7 @@ public class ResourceMessageHandler {
         final ClassLoader prevCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            connection.task(executorService.submit(() -> {
+            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, () -> {
                 try {
                     MethodMetadata methodMetadata = metadata.method();
                     Class<?> clazz = classLoader.loadClass(methodMetadata.declaringClassName());
@@ -217,6 +218,7 @@ public class ResourceMessageHandler {
                         } catch (Throwable ex) {
                             ROOT_LOGGER.errorInvokingResource(ex, resourceUri);
                             responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
+                            return;
                         }
                     } else {
                         ROOT_LOGGER.debugf("Singleton instance not found for resource %s, using reflection", resourceUri);
@@ -253,7 +255,7 @@ public class ResourceMessageHandler {
                     ROOT_LOGGER.errorInvokingResource(ex, resourceUri);
                     responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                 }
-            }));
+            })));
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(prevCL);
         }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceTemplateMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceTemplateMessageHandler.java
@@ -27,6 +27,7 @@ import static org.wildfly.extension.mcp.server.MCPServerUtils.prepareArguments;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
+import static org.wildfly.extension.mcp.server.MCPServerUtils.runWithCDIContext;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -124,7 +125,7 @@ public class ResourceTemplateMessageHandler {
         final ClassLoader prevCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            connection.task(executorService.submit(() -> {
+            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, () -> {
                 try {
                     MethodMetadata methodMetadata = metadata.method();
                     Class<?> clazz = classLoader.loadClass(methodMetadata.declaringClassName());
@@ -144,6 +145,7 @@ public class ResourceTemplateMessageHandler {
                         } catch (Throwable ex) {
                             ROOT_LOGGER.errorInvokingResourceTemplate(ex, resourceUri);
                             responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
+                            return;
                         }
                     } else {
                         ROOT_LOGGER.debugf("Singleton instance not found for resource template %s, using reflection", resourceUri);
@@ -180,7 +182,7 @@ public class ResourceTemplateMessageHandler {
                     ROOT_LOGGER.errorInvokingResourceTemplate(ex, resourceUri);
                     responder.sendError(id, INTERNAL_ERROR, ex.getMessage());
                 }
-            }));
+            })));
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(prevCL);
         }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
@@ -36,7 +36,7 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
-
+import static org.wildfly.extension.mcp.server.MCPServerUtils.runWithCDIContext;
 import static org.wildfly.extension.mcp.server.MCPServerUtils.SHARED_MAPPER;
 import static org.wildfly.extension.mcp.server.MCPServerUtils.getRequestId;
 import static org.wildfly.extension.mcp.server.MCPServerUtils.invokeViaReflection;
@@ -77,6 +77,7 @@ import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.mcp.api.elicitation.ElicitationSender;
+import org.wildfly.extension.mcp.injection.elicitation.ElicitationSenderHolder;
 import org.wildfly.extension.mcp.injection.tool.ArgumentMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPTool;
@@ -362,13 +363,14 @@ public class ToolMessageHandler {
         final ClassLoader prevCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            connection.task(executorService.submit(() -> {
+            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, () -> {
                 try {
                     MethodMetadata methodMetadata = metadata.method();
                     Class<?> clazz = classLoader.loadClass(methodMetadata.declaringClassName());
                     Instance<?> beanInstance = CDI.current().select(clazz, MCPTool.MCPToolLiteral.INSTANCE);
                     Object result = null;
-                    Object[] builtArgs = buildArguments(metadata, args, mapper, connection, responder, finalProgressToken);
+                    ElicitationSender elicitationSender = ElicitationSenderHolder.get();
+                    Object[] builtArgs = buildArguments(metadata, args, mapper, elicitationSender, responder, finalProgressToken);
                     if (beanInstance.isResolvable()) {
                         ROOT_LOGGER.debugf("The Singleton instance of the tool %s has been found", toolName);
                         try {
@@ -428,11 +430,10 @@ public class ToolMessageHandler {
                 } catch (MCPException e) {
                     MCPException.sendError(e, id, responder);
                 } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | SecurityException | ClassNotFoundException | InstantiationException | IllegalArgumentException ex) {
-                    // Infrastructure error: use a generic message to avoid leaking internal details
                     ROOT_LOGGER.errorInvokingTool(ex, toolName);
                     sendInvocationFailureResult(id, ex, responder);
                 }
-            }));
+            })));
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(prevCL);
         }
@@ -446,7 +447,7 @@ public class ToolMessageHandler {
             MCPFeatureMetadata metadata,
             Map<String, JsonValue> jsonArgs,
             ObjectMapper objectMapper,
-            MCPConnection connection,
+            ElicitationSender elicitationSender,
             Responder responder,
             ProgressToken progressToken) throws MCPException {
         if (metadata.arguments().isEmpty()) {
@@ -456,10 +457,7 @@ public class ToolMessageHandler {
         int idx = 0;
         for (ArgumentMetadata arg : metadata.arguments()) {
             if (arg.type() instanceof Class<?> clazz && ElicitationSender.class.isAssignableFrom(clazz)) {
-                ret[idx] = new ElicitationSenderImpl(
-                        connection.pendingRequests(),
-                        responder,
-                        connection.initializeRequest());
+                ret[idx] = elicitationSender;
             } else if (arg.type() instanceof Class<?> clazz && Progress.class.isAssignableFrom(clazz)) {
                 ret[idx] = new ProgressImpl(progressToken, responder);
             } else {


### PR DESCRIPTION
Make `ElicitationSender` injectable with CDI during MCP invocation (tool calls, prompt & resource templates retrieval).

Refactored the code to remove duplication between the various handlers.

Once this PR is merged, the same CDI injection can be applied to other resources (progression, notifications, etc.) 

This fixes #328 