### PR TITLE
chore: Update references to wildfly-extras

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ If you like our project, but just don’t have time to contribute, that’s fine
 * Check out our [youtube](https://www.youtube.com/@WildFlyAS) contents.
 
 ## Forking the Project 
-To contribute, you will first need to fork the [wildfly-ai-feature-pack](https://github.com/wildfly-extras/wildfly-ai-feature-pack) repository. 
+To contribute, you will first need to fork the [wildfly-ai-feature-pack](https://github.com/wildfly/wildfly-ai-feature-pack) repository. 
 
 This can be done by looking in the top-right corner of the repository page and clicking "Fork".
 
@@ -32,7 +32,7 @@ Now you have the repository on your computer!
 
 ## Issues
 
-WildFly AI Feature Pack uses GitHub Issues to manage issues. All issues can be found [here](https://github.com/wildfly-extras/wildfly-ai-feature-pack/issues).
+WildFly AI Feature Pack uses GitHub Issues to manage issues. All issues can be found [here](https://github.com/wildfly/wildfly-ai-feature-pack/issues).
 
 ## Setting up your Developer Environment
 You will need:
@@ -49,7 +49,7 @@ Add a remote ref to upstream, for pulling future updates.
 For example:
 
 ```
-git remote add upstream https://github.com/wildfly-extras/wildfly-ai-feature-pack
+git remote add upstream https://github.com/wildfly/wildfly-ai-feature-pack
 ```
 To build `wildfly-ai-feature-pack` run:
 ```bash

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ and provision it using the following command:
 galleon.sh provision provisioning.xml --dir=my-wildfly-server
 ```
 
-## Provisioning using the [WildFly Maven Plugin](https://github.com/wildfly/wildfly-maven-plugin/) or the [WildFly JAR Maven plugin](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/)
+## Provisioning using the [WildFly Maven Plugin](https://github.com/wildfly/wildfly-maven-plugin/) or the [WildFly JAR Maven plugin](https://github.com/wildfly/wildfly-jar-maven-plugin/)
 
 You need to include the AI feature-pack and layers in the Maven Plugin configuration. This looks like:
 

--- a/ai-feature-pack/src/main/resources/layers/standalone/chat-memory-provider/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/chat-memory-provider/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for ChatMemory"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/chat-memory-provider/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/chat-memory-provider/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,chat-memory-provider"/>
         <prop name="org.wildfly.rule.add-on-description" value="Chat Memory Provider to keep track of the exchanges with a LLM"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/chroma-embedding-store/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/chroma-embedding-store/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for ChromaDB as an embedding store"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/chroma-embedding-store/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/chroma-embedding-store/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-embedding-store,chroma-embedding-store"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Chroma as an embedding store"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/default-embedding-content-retriever/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/default-embedding-content-retriever/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for a default embedding content retriever using in memory embedding store and all-minilm-l6-v2 embedding model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/default-embedding-content-retriever/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/default-embedding-content-retriever/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="ai-content-retriever,default-embedding-content-retriever"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use embedding content retriever"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/gemini-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/gemini-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Gemini chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/gemini-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/gemini-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,gemini-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Github Models API for LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/gemini-streaming-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/gemini-streaming-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Gemini streaming chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/gemini-streaming-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/gemini-streaming-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,gemini-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Github Models for LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/github-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/github-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Github chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/github-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/github-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,github-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Github Models API for LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/github-streaming-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/github-streaming-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Github streaming chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/github-streaming-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/github-streaming-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,github-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Github Models for LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/groq-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/groq-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Groq chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/groq-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/groq-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,groq-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use OpenAI API for GROQ LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/groq-streaming-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/groq-streaming-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Groq streaming chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/groq-streaming-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/groq-streaming-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,groq-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use OpenAI API for GROQ LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/in-memory-embedding-store/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/in-memory-embedding-store/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support In Memory embedding store."/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/in-memory-embedding-store/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/in-memory-embedding-store/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-embedding-store,in-memory-embedding-store"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use an in memory embedding store"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/mcp-client-sse/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mcp-client-sse/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for MCP SSE client"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/mcp-client-sse/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/mcp-client-sse/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-mcp-client,mcp-client-sse"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use MCP SSE client as tool provider LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/mistral-ai-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mistral-ai-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Mistral chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/mistral-ai-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/mistral-ai-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,mistral-ai-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use MistralAI API for LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/mistral-ai-streaming-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/mistral-ai-streaming-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Mistral streaming chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/mistral-ai-streaming-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/mistral-ai-streaming-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,mistral-ai-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use MistralAI API for LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/neo4j-content-retriever/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/neo4j-content-retriever/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Neo4J content retriever"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/neo4j-content-retriever/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/neo4j-content-retriever/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-content-retriever,neo4j-content-retriever"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Neo4J as a content retriever"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/neo4j-embedding-store/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/neo4j-embedding-store/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Neo4J embedding store"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/neo4j-embedding-store/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/neo4j-embedding-store/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-embedding-store,neo4j-embedding-store"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Neo4J as an embedding store"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/ollama-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/ollama-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Ollama chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/ollama-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/ollama-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,ollama-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use ollama for LLM interactions and embeddings"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/ollama-embedding-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/ollama-embedding-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Ollama embedding model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/ollama-embedding-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/ollama-embedding-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-embedding-model,ollama-embedding-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use ollama for embedding"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/ollama-neo4j-content-retriever/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/ollama-neo4j-content-retriever/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Neo4J content retriever using Ollama model for query generation"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/neo4j-content-retriever/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/neo4j-content-retriever/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-content-retriever,neo4j-content-retriever"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Neo4J as a content retriever"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/ollama-streaming-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/ollama-streaming-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Ollama streaming chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/ollama-streaming-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/ollama-streaming-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,ollama-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use ollama for LLM interactions and embeddings"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/openai-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/openai-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for OpenAI chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/openai-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/openai-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,openai-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use OpenAI API for LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/openai-neo4j-content-retriever/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/openai-neo4j-content-retriever/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Neo4J content retriever using OpenAI model for query generation"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/neo4j-content-retriever/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/neo4j-content-retriever/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-content-retriever,neo4j-content-retriever"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Neo4J as a content retriever"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/openai-streaming-chat-model/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/openai-streaming-chat-model/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for OpenAI streaming chat model"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/openai-streaming-chat-model/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/openai-streaming-chat-model/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-llm,openai-chat-model"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use OpenAI API for LLM interactions"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/weaviate-embedding-store/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/weaviate-embedding-store/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Weaviate embedding store"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/weaviate-embedding-store/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/weaviate-embedding-store/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-embedding-store,weaviate-embedding-store"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Weaviate as an embedding store"/>

--- a/ai-feature-pack/src/main/resources/layers/standalone/web-search-engines/layer-spec.xml
+++ b/ai-feature-pack/src/main/resources/layers/standalone/web-search-engines/layer-spec.xml
@@ -8,7 +8,7 @@
         <prop name="org.wildfly.category" value="Generative AI"/>
         <prop name="org.wildfly.description" value="Support for Web Search Engine content retriever"/>
         <prop name="org.wildfly.stability" value="experimental"/>
-        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/web-search-engines/env.yaml"/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly/wildfly-ai-feature-pack/refs/heads/main/doc/glow-layer-doc/web-search-engines/env.yaml"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="ai"/>
         <prop name="org.wildfly.rule.add-on" value="ai-content-retriever,web-search-engines"/>
         <prop name="org.wildfly.rule.add-on-description" value="Use Web search engines as content retrievers"/>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <name>Parent AI integration for WildFly</name>
     <description>Parent of the feature pack for AI integration in WildFly</description>
-    <url>https://github.com/wildfly-extras/wildfly-ai-feature-pack</url>
+    <url>https://github.com/wildfly/wildfly-ai-feature-pack</url>
 
     <licenses>
         <license>
@@ -24,10 +24,10 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:wildfly-extras/wildfly-ai-feature-pack.git</connection>
-        <developerConnection>scm:git:git@github.com:wildfly-extras/wildfly-ai-feature-pack.git</developerConnection>
-        <url>https://github.com/wildfly-extras/wildfly-ai-feature-pack</url>
-        <tag>0.8.1</tag>
+        <connection>scm:git:git@github.com:wildfly/wildfly-ai-feature-pack.git</connection>
+        <developerConnection>scm:git:git@github.com:wildfly/wildfly-ai-feature-pack.git</developerConnection>
+        <url>https://github.com/wildfly/wildfly-ai-feature-pack</url>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>
@@ -92,8 +92,8 @@
 
         <!-- Nexus deployment settings -->
         <nexus.staging.tag>ai-feature-pack-${project.version}</nexus.staging.tag>
-        <nexus.repository.staging>wildfly-extras-staging</nexus.repository.staging>
-        <nexus.repository.release>wildfly-extras</nexus.repository.release>
+        <nexus.repository.staging>wildfly-staging</nexus.repository.staging>
+        <nexus.repository.release>wildfly</nexus.repository.release>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
The repository is now hosted by the wildfly organization. GitHub redirects the URLs but let's directly hit the correct ones.

For Nexus deployment, the project will now uses the wildfly-staging to stage its releases and publish them in the `wildfly` Nexus repository.