### PR TITLE
fix: correct bugs and remove dead code across ai, mcp and wasm subsys…

### DIFF
--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/AILogger.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/AILogger.java
@@ -20,7 +20,4 @@ public interface AILogger extends BasicLogger {
     @Message(id = 1, value = "The bean name %s is expecting a %s while the llm is configured as streaming %s")
     IllegalStateException incorrectLLMConfiguration(String name, String typeClass, boolean streaming);
 
-//    @Message(id = 2, value = "No HTTP Session is available to create a ChatMemory %s")
-//    IllegalStateException noHttpSession(String name);
-
 }

--- a/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/retriever/TavilyWebSearchContentRetrieverConfig.java
+++ b/wildfly-ai/injection/src/main/java/org/wildfly/extension/ai/injection/retriever/TavilyWebSearchContentRetrieverConfig.java
@@ -66,7 +66,7 @@ public class TavilyWebSearchContentRetrieverConfig implements WildFlyContentRetr
     }
 
     public TavilyWebSearchContentRetrieverConfig includeRawContent(Boolean includeRawContent) {
-        this.includeRawContent = this.includeRawContent;
+        this.includeRawContent = includeRawContent;
         return this;
     }
 

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/Capabilities.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/Capabilities.java
@@ -109,6 +109,5 @@ public interface Capabilities {
 
     String MANAGED_EXECUTOR_CAPABILITY_NAME = "org.wildfly.ee.concurrent.executor";
     String OPENTELEMETRY_CAPABILITY_NAME = "org.wildfly.extension.opentelemetry";
-    String OPENTELEMETRY_CONFIG_CAPABILITY_NAME = "org.wildfly.extension.opentelemetry.config";
     String OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.outbound-socket-binding";
 }

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/deployment/AIDeploymentProcessor.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/deployment/AIDeploymentProcessor.java
@@ -141,7 +141,7 @@ public class AIDeploymentProcessor implements DeploymentUnitProcessor {
                     }
                 }
                 if (!requiredEmbeddingStores.isEmpty()) {
-                    for (int i = 0; i < requiredEmbeddingModels.size(); i++) {
+                    for (int i = 0; i < requiredEmbeddingStores.size(); i++) {
                         WildFlyBeanRegistry.registerEmbeddingStore(requiredEmbeddingStoreNames.get(i), requiredEmbeddingStores.get(i));
                     }
                 }
@@ -166,6 +166,7 @@ public class AIDeploymentProcessor implements DeploymentUnitProcessor {
                 }
             }
         } catch (CapabilityServiceSupport.NoSuchCapabilityException e) {
+            ROOT_LOGGER.cdiRequired();
         }
     }
 

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientSseProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientSseProviderRegistrar.java
@@ -69,8 +69,4 @@ public class McpClientSseProviderRegistrar implements ChildResourceDefinitionReg
         return resourceRegistration;
     }
 
-    private enum SseScheme {
-        http, https;
-    }
-
 }

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientStreamableProviderRegistrar.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientStreamableProviderRegistrar.java
@@ -69,8 +69,4 @@ public class McpClientStreamableProviderRegistrar implements ChildResourceDefini
         return resourceRegistration;
     }
 
-    private enum SseScheme {
-        http, https;
-    }
-
 }

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientStreamableServiceConfigurator.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientStreamableServiceConfigurator.java
@@ -66,6 +66,7 @@ public class McpClientStreamableServiceConfigurator implements ResourceServiceCo
         };
         return CapabilityServiceInstaller.builder(MCP_CLIENT_CAPABILITY, factory)
                 .requires(outboundSocketBinding)
+                .requires(executorService)
                 .blocking()
                 .startWhen(Installer.StartWhen.INSTALLED)
                 .build();

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
@@ -31,15 +31,12 @@ public interface MCPLogger extends BasicLogger {
     @Message(id = 3, value = "Parameter %s must be positive")
     IllegalArgumentException parameterMustBePositive(String name);
 
-//    @Message(id = 4, value = "At least one schema property must be added to the Elicitation Form")
-//    IllegalArgumentException mustHaveAtLeastOneSchemaProperty();
-
-    @Message(id = 5, value = "Parameter %s must not be empty")
+    @Message(id = 4, value = "Parameter %s must not be empty")
     IllegalArgumentException parameterMustNotBeEmpty(String name);
 
-    @Message(id = 6, value = "Parameter %s must have the same size as parameter %s")
+    @Message(id = 5, value = "Parameter %s must have the same size as parameter %s")
     IllegalArgumentException parameterMustHaveSameSize(String parameter1, String parameter2);
 
-    @Message(id = 7, value = "Parameter 'max' (%s) can not be less than 'min' (%s) ")
+    @Message(id = 6, value = "Parameter 'max' (%s) can not be less than 'min' (%s) ")
     IllegalArgumentException maxCanNotBeLessThanMin(Integer max, Integer min);
 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/Capabilities.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/Capabilities.java
@@ -12,7 +12,4 @@ public interface Capabilities {
 
     NullaryServiceDescriptor<MCPEndpointConfiguration> MCP_SERVER_PROVIDER_DESCRIPTOR = NullaryServiceDescriptor.of("org.wildfly.ai.mcp.server.configuration", MCPEndpointConfiguration.class);
     RuntimeCapability<Void> MCP_SERVER_PROVIDER_CAPABILITY = RuntimeCapability.Builder.of(MCP_SERVER_PROVIDER_DESCRIPTOR).setAllowMultipleRegistrations(false).build();
-
-    String UNDERTOW_HOST_CAPABILITY_NAME = "org.wildfly.undertow.host";
-    String UNDERTOW_SERVER_CAPABILITY_NAME = "org.wildfly.undertow.server";
 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPLogger.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPLogger.java
@@ -130,39 +130,36 @@ public interface MCPLogger extends BasicLogger {
     @Message(id = 28, value = "Invalid tool name: %s")
     String invalidToolName(String tool);
 
-//    @Message(id = 29, value = "Failed to serialize structured content")
-//    String errorSerializingContent();
-
-    @Message(id = 30, value = "Tool invocation failed")
+    @Message(id = 29, value = "Tool invocation failed")
     String errorInvokingTool();
 
-    @Message(id = 31, value = "pageSize must not be negative: %d")
+    @Message(id = 30, value = "pageSize must not be negative: %d")
     IllegalArgumentException invalidPageSize(int pageSize);
 
-    @Message(id = 32, value = "Invalid prompt name: %s")
+    @Message(id = 31, value = "Invalid prompt name: %s")
     String invalidPromptName(String prompt);
 
-    @Message(id = 33, value = "Invalid resource name: %s")
+    @Message(id = 32, value = "Invalid resource name: %s")
     String invalidResourceName(String resourceUri);
 
-    @Message(id = 34, value = "Resource URI not defined")
+    @Message(id = 33, value = "Resource URI not defined")
     String resourceUriNotDefined();
 
-    @Message(id = 35, value = "No resource template matches URI: %s")
+    @Message(id = 34, value = "No resource template matches URI: %s")
     String noMatchingResourceTemplate(String resourceUri);
 
     @LogMessage(level = ERROR)
-    @Message(id = 36, value = "Skipping tool '%s' from listing (schema generation failed): %s")
+    @Message(id = 35, value = "Skipping tool '%s' from listing (schema generation failed): %s")
     void errorSkippingToolFromListing(String toolName, String reason);
 
     @LogMessage(level = WARN)
-    @Message(id = 37, value = "Schema generator class '%s' does not implement ToolSchemaGenerator")
+    @Message(id = 36, value = "Schema generator class '%s' does not implement ToolSchemaGenerator")
     void warnSchemaGeneratorInvalidType(String className);
 
     @LogMessage(level = WARN)
-    @Message(id = 38, value = "Failed to resolve schema generator '%s'")
+    @Message(id = 37, value = "Failed to resolve schema generator '%s'")
     void warnFailedToResolveSchemaGenerator(@Cause Throwable cause, String className);
 
-    @Message(id = 39, value = "Client does not support %s mode elicitation")
+    @Message(id = 38, value = "Client does not support %s mode elicitation")
     IllegalStateException elicitationModeNotSupported(Elicitation.Mode mode);
 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/JsonRPC.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/JsonRPC.java
@@ -18,13 +18,10 @@ public class JsonRPC {
 
     public static final String VERSION = "2.0";
 
-    public static final int RESOURCE_NOT_FOUND = -32002;
-
     public static final int INTERNAL_ERROR = -32603;
     public static final int INVALID_PARAMS = -32602;
     public static final int METHOD_NOT_FOUND = -32601;
     public static final int INVALID_REQUEST = -32600;
-    public static final int PARSE_ERROR = -32700;
 
     public static boolean validate(JsonObject message, Responder responder) {
         String id = message.get("id") == null ? null : message.get("id").toString();

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/CompletionHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/CompletionHandler.java
@@ -6,7 +6,6 @@ package org.wildfly.extension.mcp.server;
 
 import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.JsonRPC.INTERNAL_ERROR;
-import static org.wildfly.extension.mcp.api.JsonRPC.INVALID_PARAMS;
 import static org.wildfly.extension.mcp.api.JsonRPC.INVALID_REQUEST;
 
 import jakarta.enterprise.inject.Instance;
@@ -23,7 +22,6 @@ import java.util.Map;
 import org.mcp_java.model.common.CompleteContext;
 import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
-import org.wildfly.extension.mcp.MCPLogger;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.extension.mcp.injection.tool.ArgumentMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPMessageHandler.java
@@ -125,7 +125,6 @@ public class MCPMessageHandler {
     static final String PROTOCOL_VERSION = "2025-03-26";
     static final String INITIALIZE = "initialize";
     static final String NOTIFICATIONS_INITIALIZED = "notifications/initialized";
-    static final String NOTIFICATIONS_MESSAGE = "notifications/message";
     static final String NOTIFICATIONS_CANCEL = "notifications/cancelled";
     static final String PROMPTS_LIST = "prompts/list";
     static final String PROMPTS_GET = "prompts/get";

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPServerUtils.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPServerUtils.java
@@ -21,7 +21,6 @@ import jakarta.json.JsonValue.ValueType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import org.wildfly.extension.mcp.api.Responder;

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
@@ -36,11 +36,13 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
+
 import static org.wildfly.extension.mcp.server.MCPServerUtils.SHARED_MAPPER;
 import static org.wildfly.extension.mcp.server.MCPServerUtils.getRequestId;
 import static org.wildfly.extension.mcp.server.MCPServerUtils.invokeViaReflection;
 import static org.wildfly.extension.mcp.server.MCPServerUtils.prepareArguments;
 import static org.wildfly.extension.mcp.server.MCPServerUtils.sendInvocationFailureResult;
+
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -60,7 +62,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/Capabilities.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/Capabilities.java
@@ -12,7 +12,4 @@ public interface Capabilities {
     String MCP_CAPABILITY_NAME = "org.wildfly.ai.mcp.server";
     UnaryServiceDescriptor<WasmToolConfiguration> WASM_TOOL_PROVIDER_DESCRIPTOR = UnaryServiceDescriptor.of("org.wildfly.ai.mcp.server.wasm.tool", WasmToolConfiguration.class);
     RuntimeCapability<Void> WASM_TOOL_PROVIDER_CAPABILITY = RuntimeCapability.Builder.of(WASM_TOOL_PROVIDER_DESCRIPTOR).setAllowMultipleRegistrations(true).build();
-
-    String UNDERTOW_HOST_CAPABILITY_NAME = "org.wildfly.undertow.host";
-    String UNDERTOW_SERVER_CAPABILITY_NAME = "org.wildfly.undertow.server";
 }

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmLogger.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/WasmLogger.java
@@ -28,7 +28,4 @@ public interface WasmLogger extends BasicLogger {
     @Message(id = 2, value = "Unable to resolve annotation index for deployment unit: %s")
     DeploymentUnitProcessingException unableToResolveAnnotationIndex(DeploymentUnit deploymentUnit);
 
-//    @Message(id = 3, value = "Failed to resolve module for deployment %s")
-//    DeploymentUnitProcessingException failedToResolveModule(DeploymentUnit deploymentUnit);
-
 }

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmAttachements.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmAttachements.java
@@ -9,6 +9,5 @@ import org.jboss.as.server.deployment.AttachmentList;
 import org.wildfly.extension.wasm.injection.WasmToolConfiguration;
 
 public class WasmAttachements {
-    static final AttachmentKey<AttachmentList<String>> WASM_TOOL_NAMES = AttachmentKey.createList(String.class);
     static final AttachmentKey<AttachmentList<WasmToolConfiguration>> WASM_TOOL_CONFIGURATIONS = AttachmentKey.createList(WasmToolConfiguration.class);
 }

--- a/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmDependencyProcessor.java
+++ b/wildfly-wasm/subsystem/src/main/java/org/wildfly/extension/wasm/deployment/WasmDependencyProcessor.java
@@ -47,32 +47,27 @@ public class WasmDependencyProcessor implements DeploymentUnitProcessor {
         if (annotations == null || annotations.isEmpty()) {
             return;
         }
-        DeploymentUnit deploymentUnit = deploymentPhaseContext.getDeploymentUnit();
         for (AnnotationInstance annotation : annotations) {
+            String annotationValue = annotation.value() != null ? annotation.value().asString() : null;
             String name;
-            if(annotation.value("name") != null) {
-                name = annotation.value("name").asString();
-            }else {
-                if(annotation.target().kind() == Kind.FIELD) {
-                   name = annotation.target().asField().name();
-                } else {
-                    name = annotation.target().asMethodParameter().name();
-                }
+            if (annotationValue != null && !annotationValue.isEmpty()) {
+                name = annotationValue;
+            } else if (annotation.target().kind() == Kind.FIELD) {
+                name = annotation.target().asField().name();
+            } else {
+                name = annotation.target().asMethodParameter().name();
             }
-            deploymentUnit.addToAttachmentList(WasmAttachements.WASM_TOOL_NAMES, name);
             deploymentPhaseContext.addDeploymentDependency(WASM_TOOL_PROVIDER_CAPABILITY.getCapabilityServiceName(name), WasmAttachements.WASM_TOOL_CONFIGURATIONS);
         }
     }
+
     private void processWasmToolServices(DeploymentPhaseContext deploymentPhaseContext, List<AnnotationInstance> annotations) {
         if (annotations == null || annotations.isEmpty()) {
             return;
         }
-        DeploymentUnit deploymentUnit = deploymentPhaseContext.getDeploymentUnit();
         for (AnnotationInstance annotation : annotations) {
-            String name;
             if (annotation.value("wasmToolConfigurationName") != null) {
-                name = annotation.value("wasmToolConfigurationName").asString();
-                deploymentUnit.addToAttachmentList(WasmAttachements.WASM_TOOL_NAMES, name);
+                String name = annotation.value("wasmToolConfigurationName").asString();
                 deploymentPhaseContext.addDeploymentDependency(WASM_TOOL_PROVIDER_CAPABILITY.getCapabilityServiceName(name), WasmAttachements.WASM_TOOL_CONFIGURATIONS);
             }
         }


### PR DESCRIPTION
…tems

- Fix self-assignment no-op in TavilyWebSearchContentRetrieverConfig.includeRawContent()
- Fix loop guard using wrong collection size in AIDeploymentProcessor
- Add missing executorService dependency in McpClientStreamableServiceConfigurator
- Log CDI unavailability instead of silently swallowing NoSuchCapabilityException
- Restore method-parameter injection support in WasmDependencyProcessor
- Remove unused SseScheme enums, dead Undertow/OpenTelemetry/JsonRPC constants, and unused imports
- Delete commented-out @Message methods and renumber remaining message IDs