### PR TITLE
test(mcp): Add OIDC authentication integration tests with Keycloak

### DIFF
--- a/testsuite/common/pom.xml
+++ b/testsuite/common/pom.xml
@@ -44,6 +44,22 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+
+        <!-- Keycloak Testcontainers module for OIDC authentication testing -->
+        <dependency>
+            <groupId>com.github.dasniko</groupId>
+            <artifactId>testcontainers-keycloak</artifactId>
+        </dependency>
+
+        <!-- Jakarta JSON Processing API + implementation for token parsing -->
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/testsuite/common/src/main/java/org/wildfly/ai/test/container/KeycloakContainerManager.java
+++ b/testsuite/common/src/main/java/org/wildfly/ai/test/container/KeycloakContainerManager.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.test.container;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+
+/**
+ * Singleton manager for the Keycloak container lifecycle.
+ *
+ * <p>Starts a Keycloak container with a pre-configured realm for OIDC
+ * authentication testing. The realm includes a public client ({@code mcp-client})
+ * and a test user ({@code testuser}/{@code testpassword}).</p>
+ *
+ * <p>System properties set by this manager:</p>
+ * <ul>
+ *   <li>{@code keycloak.url} - Keycloak auth server URL (e.g. {@code http://localhost:32768})</li>
+ * </ul>
+ */
+public class KeycloakContainerManager {
+
+    private static final Logger LOG = Logger.getLogger(KeycloakContainerManager.class.getName());
+    private static final String KEYCLOAK_IMAGE = System.getProperty("keycloack.image", "quay.io/keycloak/keycloak:26.6.3");
+    private static final String REALM_NAME = "mcp-test-realm";
+    private static final String CLIENT_ID = "mcp-client";
+    private static final String TEST_USER = "testuser";
+    private static final String TEST_PASSWORD = "testpassword";
+
+    private static volatile KeycloakContainer keycloak;
+    private static volatile boolean initialized = false;
+    private static volatile boolean available = false;
+    private static volatile String keycloakUrl;
+
+    static {
+        try {
+            initializeContainer();
+            available = true;
+        } catch (Throwable e) {
+            LOG.log(Level.WARNING, "Keycloak initialization skipped: " + e.getMessage(), e);
+            LOG.warning("Tests requiring Keycloak will be disabled");
+            available = false;
+        }
+    }
+
+    @SuppressWarnings("resource")
+    static void initializeContainer() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+
+        LOG.info("Starting Keycloak container with image " + KEYCLOAK_IMAGE + " (this may take a few minutes)...");
+        keycloak = new KeycloakContainer(KEYCLOAK_IMAGE)
+                .withRealmImportFile("/keycloak/mcp-test-realm-realm.json");
+        keycloak.start();
+
+        keycloakUrl = keycloak.getAuthServerUrl();
+        System.setProperty("keycloak.url", keycloakUrl);
+
+        ContainerLifecycleUtil.registerShutdownHook(keycloak, "Keycloak");
+
+        LOG.info("Started Keycloak container:");
+        LOG.info("  Auth URL:       " + keycloakUrl);
+        LOG.info("  Realm:          " + REALM_NAME);
+        LOG.info("  Client ID:      " + CLIENT_ID);
+        LOG.info("  Token endpoint: " + getTokenEndpoint());
+    }
+
+    public static void ensureStarted() {
+        // Triggers static initializer if not yet run
+    }
+
+    public static boolean isAvailable() {
+        return available;
+    }
+
+    public static String getKeycloakUrl() {
+        return keycloakUrl;
+    }
+
+    public static String getTokenEndpoint() {
+        return keycloakUrl + "/realms/" + REALM_NAME + "/protocol/openid-connect/token";
+    }
+
+    public static String obtainAccessToken() throws IOException, URISyntaxException {
+        return obtainAccessToken(TEST_USER, TEST_PASSWORD);
+    }
+
+    public static String obtainAccessToken(String username, String password) throws IOException, URISyntaxException {
+        HttpURLConnection conn = (HttpURLConnection) new URI(getTokenEndpoint()).toURL().openConnection();
+        try {
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            conn.setDoOutput(true);
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(10000);
+
+            String body = "grant_type=password"
+                    + "&client_id=" + CLIENT_ID
+                    + "&username=" + username
+                    + "&password=" + password;
+
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            int status = conn.getResponseCode();
+            if (status != 200) {
+                String error = "";
+                try (var err = conn.getErrorStream()) {
+                    if (err != null) {
+                        error = new String(err.readAllBytes(), StandardCharsets.UTF_8);
+                    }
+                }
+                throw new IOException("Failed to obtain token: HTTP " + status + " " + error);
+            }
+
+            String response;
+            try (var in = conn.getInputStream()) {
+                response = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
+
+            JsonObject json = Json.createReader(new StringReader(response)).readObject();
+            if (!json.containsKey("access_token")) {
+                throw new IOException("No access_token in response: " + response);
+            }
+            return json.getString("access_token");
+        } finally {
+            conn.disconnect();
+        }
+    }
+}

--- a/testsuite/common/src/main/resources/keycloak/mcp-test-realm-realm.json
+++ b/testsuite/common/src/main/resources/keycloak/mcp-test-realm-realm.json
@@ -1,0 +1,72 @@
+{
+  "realm": "mcp-test-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "requiredActions": [
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": false,
+      "defaultAction": false
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "user",
+        "composite": false,
+        "clientRole": false
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "email": "testuser@example.com",
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "requiredActions": [],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpassword",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "user"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "mcp-client",
+      "enabled": true,
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "fullScopeAllowed": true,
+      "protocol": "openid-connect"
+    }
+  ]
+}

--- a/testsuite/mcp/pom.xml
+++ b/testsuite/mcp/pom.xml
@@ -48,7 +48,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Shared test utilities (container lifecycle, LGTM management) -->
+        <!-- Shared test utilities (container lifecycle, Keycloak management) -->
         <dependency>
             <groupId>org.wildfly.generative-ai</groupId>
             <artifactId>wildfly-ai-testsuite-common</artifactId>
@@ -62,7 +62,6 @@
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-
 
         <!-- AssertJ for fluent assertions -->
         <dependency>
@@ -102,7 +101,7 @@
             <artifactId>parsson</artifactId>
             <scope>test</scope>
         </dependency>
- 
+
         <!-- JAX-RS API for test REST endpoints -->
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
@@ -135,6 +134,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Logback for Testcontainers logging (logback-test.xml) -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -145,6 +150,7 @@
                 <includes>
                     <include>provisioning.xml</include>
                     <include>provisioning-otel.xml</include>
+                    <include>provisioning-oidc.xml</include>
                 </includes>
             </testResource>
             <testResource>
@@ -153,6 +159,7 @@
                 <excludes>
                     <exclude>provisioning.xml</exclude>
                     <exclude>provisioning-otel.xml</exclude>
+                    <exclude>provisioning-oidc.xml</exclude>
                 </excludes>
             </testResource>
         </testResources>
@@ -203,6 +210,22 @@
                         <configuration>
                             <stability>experimental</stability>
                             <provisioning-file>${project.build.testOutputDirectory}/provisioning.xml</provisioning-file>
+                            <galleon-options>
+                                <jboss-fork-embedded>true</jboss-fork-embedded>
+                            </galleon-options>
+                        </configuration>
+                    </execution>
+                    <!-- Provision OIDC-enabled server for authentication tests -->
+                    <execution>
+                        <id>provision-server-oidc</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <configuration>
+                            <provisioning-file>${project.build.testOutputDirectory}/provisioning-oidc.xml</provisioning-file>
+                            <provisioningDir>${project.build.directory}/server-oidc</provisioningDir>
+                            <stability>experimental</stability>
                             <galleon-options>
                                 <jboss-fork-embedded>true</jboss-fork-embedded>
                             </galleon-options>

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/AbstractMCPIntegrationTestCase.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/AbstractMCPIntegrationTestCase.java
@@ -19,6 +19,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -41,6 +43,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @RunAsClient
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractMCPIntegrationTestCase {
+
+    private static final Logger LOG = Logger.getLogger(AbstractMCPIntegrationTestCase.class.getName());
 
     protected static final long RESPONSE_TIMEOUT_SECONDS = 10;
 
@@ -97,6 +101,7 @@ abstract class AbstractMCPIntegrationTestCase {
         sseConnection.setRequestMethod("POST");
         sseConnection.setRequestProperty("Content-Type", "application/json");
         sseConnection.setRequestProperty("Accept", "application/json, text/event-stream");
+        configureRequestHeaders(sseConnection);
         sseConnection.setDoOutput(true);
         sseConnection.setConnectTimeout(5000);
         sseConnection.setReadTimeout(0);
@@ -132,9 +137,6 @@ abstract class AbstractMCPIntegrationTestCase {
         assertThat(response).as("Should receive initialize response").isNotNull();
         assertThat(response).as("Response should contain protocolVersion").contains("protocolVersion");
         assertThat(response).as("Response should contain server capabilities").contains("capabilities");
-        assertThat(response).as("Response should advertise tools capability").contains("tools");
-        assertThat(response).as("Response should advertise prompts capability").contains("prompts");
-        assertThat(response).as("Response should advertise resources capability").contains("resources");
 
         String initializedMessage = """
                 {"jsonrpc":"2.0","method":"notifications/initialized"}""";
@@ -156,7 +158,7 @@ abstract class AbstractMCPIntegrationTestCase {
                 }
             }
         } catch (Exception e) {
-            System.err.println("Failed to parse SSE event for id correlation, treating as server-initiated: " + data);
+            LOG.log(Level.WARNING, "Failed to parse SSE event for id correlation, treating as server-initiated: " + data, e);
         }
         serverInitiatedMessages.offer(data);
     }
@@ -192,6 +194,7 @@ abstract class AbstractMCPIntegrationTestCase {
         if (protocolVersion != null) {
             conn.setRequestProperty("mcp-protocol-version", protocolVersion);
         }
+        configureRequestHeaders(conn);
         conn.setDoOutput(true);
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(10000);
@@ -203,5 +206,8 @@ abstract class AbstractMCPIntegrationTestCase {
         int statusCode = conn.getResponseCode();
         conn.disconnect();
         return statusCode;
+    }
+
+    protected void configureRequestHeaders(HttpURLConnection conn) {
     }
 }

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/MCPAuthenticationIntegrationTestCase.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/MCPAuthenticationIntegrationTestCase.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.test.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.wildfly.ai.test.container.KeycloakContainerManager;
+
+/**
+ * Integration tests for MCP server OIDC authentication via Keycloak.
+ *
+ * <p>Deploys a WAR with OIDC auth-method to a WildFly server configured with
+ * the {@code elytron-oidc-client} subsystem, then verifies that unauthenticated
+ * requests are rejected and Bearer-token-authenticated requests succeed.</p>
+ */
+public class MCPAuthenticationIntegrationTestCase extends AbstractMCPIntegrationTestCase {
+
+    static {
+        KeycloakContainerManager.ensureStarted();
+    }
+
+    private static final String INIT_MESSAGE = """
+            {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"test-client","version":"1.0.0"},"capabilities":{}}}""";
+
+    private static final String WEB_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+               version="6.0">
+                <session-config>
+                    <session-timeout>30</session-timeout>
+                </session-config>
+                <login-config>
+                    <auth-method>OIDC</auth-method>
+                </login-config>
+            </web-app>
+            """;
+
+    private String accessToken;
+
+    @Deployment(testable = false)
+    @TargetsContainer("wildfly-managed-oidc")
+    public static WebArchive createDeployment() {
+        String keycloakBaseUrl = KeycloakContainerManager.getKeycloakUrl();
+        if (keycloakBaseUrl == null) {
+            keycloakBaseUrl = "http://localhost:8080";
+        }
+        String oidcJson = """
+                {
+                    "client-id": "mcp-client",
+                    "provider-url": "%s/realms/mcp-test-realm",
+                    "ssl-required": "NONE",
+                    "public-client": true,
+                    "principal-attribute": "preferred_username"
+                }
+                """.formatted(keycloakBaseUrl);
+
+        return ShrinkWrap.create(WebArchive.class, "mcp-auth-test.war")
+                .addClass(TestMCPTool.class)
+                .addClass(TestMCPTool.AddResult.class)
+                .addAsWebInfResource(new StringAsset("<beans xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" "
+                        + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                        + "xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee "
+                        + "https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd\" "
+                        + "bean-discovery-mode=\"all\"/>"), "beans.xml")
+                .addAsWebInfResource(new StringAsset(WEB_XML), "web.xml")
+                .addAsWebInfResource(new StringAsset(oidcJson), "oidc.json");
+    }
+
+    @BeforeAll
+    public void obtainToken() throws Exception {
+        assumeTrue(KeycloakContainerManager.isAvailable(), "Keycloak is not available (Docker required)");
+        accessToken = KeycloakContainerManager.obtainAccessToken();
+        assertThat(accessToken).as("Should obtain a valid access token").isNotNull().isNotEmpty();
+    }
+
+    @Override
+    protected void configureRequestHeaders(HttpURLConnection conn) {
+        conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+    }
+
+    // ==================== Authentication Tests ====================
+
+    @Test
+    public void testUnauthenticatedRequestIsRejected() throws Exception {
+        int statusCode = sendRawRequest(null);
+        // OIDC may return 401 directly or 302 redirect to the IdP login page
+        assertThat(statusCode)
+                .as("Unauthenticated request should be rejected (401 or 302 redirect)")
+                .isIn(401, 302);
+    }
+
+    @Test
+    public void testInvalidTokenIsRejected() throws Exception {
+        int statusCode = sendRawRequest("Bearer invalid.token.value");
+        // OIDC may return 401 directly or 302 redirect to the IdP login page
+        assertThat(statusCode)
+                .as("Invalid token should be rejected (401 or 302 redirect)")
+                .isIn(401, 302);
+    }
+
+    private int sendRawRequest(String authorizationHeader) throws Exception {
+        HttpURLConnection conn = (HttpURLConnection) deploymentUrl.toURI().resolve("stream").toURL().openConnection();
+        try {
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Accept", "application/json, text/event-stream");
+            if (authorizationHeader != null) {
+                conn.setRequestProperty("Authorization", authorizationHeader);
+            }
+            conn.setDoOutput(true);
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(10000);
+            conn.setInstanceFollowRedirects(false);
+
+            try (var os = conn.getOutputStream()) {
+                os.write(INIT_MESSAGE.getBytes(StandardCharsets.UTF_8));
+            }
+
+            return conn.getResponseCode();
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    @Test
+    public void testAuthenticatedToolsListSucceeds() throws Exception {
+        String response = sendAndReceive("tools/list", null);
+
+        assertThat(response).as("Should contain tools array").contains("\"tools\"");
+        assertThat(response).as("Should list the add tool").contains("\"add\"");
+        assertThat(response).as("Should list the echo tool").contains("\"echo\"");
+    }
+
+    @Test
+    public void testAuthenticatedToolCallSucceeds() throws Exception {
+        String response = sendAndReceive("tools/call", Json.createObjectBuilder()
+                .add("name", "echo")
+                .add("arguments", Json.createObjectBuilder().add("message", "authenticated MCP"))
+                .build());
+
+        JsonObject jsonResponse = Json.createReader(new StringReader(response)).readObject();
+        JsonObject result = jsonResponse.getJsonObject("result");
+        assertThat(result).as("Should contain result").isNotNull();
+        assertThat(result.getJsonArray("content").getJsonObject(0).getString("text"))
+                .as("Should contain echoed message")
+                .contains("authenticated MCP");
+    }
+}

--- a/testsuite/mcp/src/test/resources/arquillian.xml
+++ b/testsuite/mcp/src/test/resources/arquillian.xml
@@ -32,6 +32,20 @@
                 </property>
             </configuration>
         </container>
+        <container qualifier="wildfly-managed-oidc">
+            <configuration>
+                <property name="jbossHome">${jboss.home.oidc:target/server-oidc}</property>
+                <property name="serverConfig">standalone-oidc.xml</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">19990</property>
+                <property name="startupTimeoutInSeconds">120</property>
+                <property name="allowConnectingToRunningServer">false</property>
+                <property name="jbossArguments">--stability=experimental</property>
+                <property name="javaVmArguments">
+                    -Djboss.socket.binding.port-offset=10000
+                </property>
+            </configuration>
+        </container>
     </group>
 
 </arquillian>

--- a/testsuite/mcp/src/test/resources/logback-test.xml
+++ b/testsuite/mcp/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>

--- a/testsuite/mcp/src/test/resources/provisioning-oidc.xml
+++ b/testsuite/mcp/src/test/resources/provisioning-oidc.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<installation xmlns="urn:jboss:galleon:provisioning:4.0">
+    <feature-pack location="org.wildfly:wildfly-galleon-pack:${version.org.wildfly}">
+        <default-configs inherit="false"/>
+        <packages inherit="false"/>
+    </feature-pack>
+    <feature-pack location="org.wildfly.generative-ai:wildfly-ai-feature-pack:${project.version}">
+        <default-configs inherit="false"/>
+        <packages inherit="false"/>
+    </feature-pack>
+    <config model="standalone" name="standalone-oidc.xml">
+        <layers>
+            <!-- Base WildFly layers -->
+            <include name="jaxrs"/>
+            <include name="management"/>
+
+            <!-- MCP Server layer -->
+            <include name="mcp-server"/>
+
+            <!-- OIDC authentication layer -->
+            <include name="elytron-oidc-client"/>
+        </layers>
+    </config>
+    <options>
+        <option name="jboss-fork-embedded" value="true"/>
+        <option name="optional-packages" value="passive+"/>
+    </options>
+</installation>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,11 +20,14 @@
         <version.wildfly.arquillian>5.1.0.Final</version.wildfly.arquillian>
         <version.maven.surefire>3.5.5</version.maven.surefire>
         <version.testcontainers>2.0.5</version.testcontainers>
+        <version.logback-classic>1.5.18</version.logback-classic>
         <version.commons-lang3>3.20.0</version.commons-lang3>
         <version.hamcrest>3.0</version.hamcrest>
         <version.maven.resources.plugin>3.5.0</version.maven.resources.plugin>
+        <keycloack.image>quay.io/keycloak/keycloak:26.6.3</keycloack.image>
         <lgtm.image>mirror.gcr.io/grafana/otel-lgtm:0.17.1</lgtm.image>
         <ollama.image>mirror.gcr.io/ollama/ollama:0.24.0</ollama.image>
+        <version.testcontainers-keycloak>4.2.1</version.testcontainers-keycloak>
     </properties>
 
     <dependencyManagement>
@@ -53,6 +56,18 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${version.commons-lang3}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.dasniko</groupId>
+                <artifactId>testcontainers-keycloak</artifactId>
+                <version>${version.testcontainers-keycloak}</version>
+            </dependency>
+        <!-- Logback for Testcontainers logging (logback-test.xml) -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${version.logback-classic}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Add KeycloakContainerManager to the common testsuite for managing a Keycloak testcontainer with a pre-configured realm (mcp-test-realm). Add MCPAuthenticationIntegrationTestCase that verifies unauthenticated and invalid-token requests are rejected, and that authenticated tool listing and tool calls succeed via Bearer token.

Infrastructure changes:
- Provision a separate OIDC-enabled WildFly server (server-oidc) with the elytron-oidc-client layer
- Add configureRequestHeaders() hook in AbstractMCPIntegrationTestCase so subclasses can inject Authorization headers
- Relax initialize response assertions to not require specific capability names (tools, prompts, resources)