### PR TITLE
Make Progress injectable with CDI (@Inject)

### DIFF
--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/MCPServerIntegrationTestCase.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/MCPServerIntegrationTestCase.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
  * the MCP protocol via HTTP using the streamable endpoint.</p>
  *
  * <p>Elicitation tests are in {@link ElicitationIntegrationTestCase}.</p>
+ * <p>Progress tests are in {@link ProgressIntegrationTestCase}.</p>
  */
 public class MCPServerIntegrationTestCase extends AbstractMCPIntegrationTestCase {
 
@@ -37,13 +38,9 @@ public class MCPServerIntegrationTestCase extends AbstractMCPIntegrationTestCase
                 .addClass(TestMCPTool.AddResult.class)
                 .addClass(TestMCPPrompt.class)
                 .addClass(TestMCPResource.class)
-                .addClass(TestMCPProgressTool.class)
                 .addClass(TestMCPCompletion.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
-
-    private static final String NOTIFICATIONS_PROGRESS = "notifications/progress";
-    private static final String PROGRESS_TOKEN = "progressToken";
 
     @Test
     public void testPing() throws Exception {
@@ -292,93 +289,6 @@ public class MCPServerIntegrationTestCase extends AbstractMCPIntegrationTestCase
         String response = sendAndReceive("unsupported/method", null);
         assertThat(response).as("Should contain error").contains("\"error\"");
         assertThat(response).as("Should contain method not found code").contains("-32601");
-    }
-
-    // ==================== Progress Notifications ====================
-
-    @Test
-    public void testProgressToolListedWithoutProgressParam() throws Exception {
-        String response = sendAndReceive("tools/list", null);
-        assertThat(response).as("Should list the progress-test tool").contains("progress-test");
-        assertThat(response).as("Progress must not appear in inputSchema").doesNotContain("\"Progress\"");
-        assertThat(response).as("Progress must not appear as property name").doesNotContain("\"progress\"");
-    }
-
-    @Test
-    public void testProgressNotificationsSent() throws Exception {
-        long toolCallId = nextId.getAndIncrement();
-        CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
-        pendingResponses.put(toolCallId, toolResultFuture);
-
-        String toolCallMessage = """
-                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"progress-test","arguments":{"steps":"3"},"_meta":{"progressToken":"test-token-1"}}}"""
-                .formatted(toolCallId);
-        postToStreamable(toolCallMessage);
-
-        String toolResult = toolResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        assertThat(toolResult).as("Should receive tool result").isNotNull();
-
-        // Collect all progress notifications (3 steps expected)
-        for (int i = 0; i < 3; i++) {
-            String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            assertThat(notification).as("Should receive progress notification " + (i + 1)).isNotNull();
-
-            JsonObject notificationJson = Json.createReader(new StringReader(notification)).readObject();
-            assertThat(notificationJson.getString("method")).as("Should be notifications/progress")
-                    .isEqualTo(NOTIFICATIONS_PROGRESS);
-            JsonObject params = notificationJson.getJsonObject("params");
-            assertThat(params.getString(PROGRESS_TOKEN)).as("Token should match").isEqualTo("test-token-1");
-            assertThat(params.getJsonNumber("total").intValue()).as("Total should be 3").isEqualTo(3);
-            assertThat(params.getJsonNumber("progress").intValue()).as("Progress should be " + (i + 1))
-                    .isEqualTo(i + 1);
-        }
-
-        JsonObject resultJson = Json.createReader(new StringReader(toolResult)).readObject();
-        assertThat(resultJson.containsKey("result")).as("Should contain result").isTrue();
-        JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
-        assertThat(content.getJsonObject(0).getString("text")).as("Should confirm completion").contains("Completed 3 steps");
-    }
-
-    @Test
-    public void testProgressNotificationWithMessage() throws Exception {
-        long toolCallId = nextId.getAndIncrement();
-        CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
-        pendingResponses.put(toolCallId, toolResultFuture);
-
-        String toolCallMessage = """
-                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"progress-notification-test","arguments":{},"_meta":{"progressToken":"msg-token"}}}"""
-                .formatted(toolCallId);
-        postToStreamable(toolCallMessage);
-
-        String toolResult = toolResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        assertThat(toolResult).as("Should receive tool result").isNotNull();
-
-        String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        assertThat(notification).as("Should receive progress notification").isNotNull();
-
-        JsonObject notificationJson = Json.createReader(new StringReader(notification)).readObject();
-        assertThat(notificationJson.getString("method")).as("Should be notifications/progress")
-                .isEqualTo(NOTIFICATIONS_PROGRESS);
-        JsonObject params = notificationJson.getJsonObject("params");
-        assertThat(params.getString(PROGRESS_TOKEN)).as("Token should match").isEqualTo("msg-token");
-        assertThat(params.getJsonNumber("progress").intValue()).as("Progress should be 50").isEqualTo(50);
-        assertThat(params.getJsonNumber("total").intValue()).as("Total should be 100").isEqualTo(100);
-        assertThat(params.getString("message")).as("Message should be present").isEqualTo("Halfway done");
-    }
-
-    @Test
-    public void testProgressNoTokenDoesNotSendNotifications() throws Exception {
-        String response = sendAndReceive("tools/call", Json.createObjectBuilder()
-                .add("name", "progress-no-token")
-                .add("arguments", Json.createObjectBuilder())
-                .build());
-
-        JsonObject resultJson = Json.createReader(new StringReader(response)).readObject();
-        JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
-        assertThat(content.getJsonObject(0).getString("text")).as("Should report no-token").isEqualTo("no-token");
-
-        String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        assertThat(notification).as("No notifications should be sent without a token").isNull();
     }
 
     // ==================== structuredContent Tests ====================

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/ProgressIntegrationTestCase.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/ProgressIntegrationTestCase.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.test.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for MCP progress notifications, including CDI-injected Progress.
+ */
+public class ProgressIntegrationTestCase extends AbstractMCPIntegrationTestCase {
+
+    private static final String NOTIFICATIONS_PROGRESS = "notifications/progress";
+    private static final String PROGRESS_TOKEN = "progressToken";
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "mcp-progress.war")
+                .addClass(TestMCPProgressTool.class)
+                .addClass(TestMCPInjectedProgress.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    // ==================== Method Parameter Progress (tools only) ====================
+
+    @Test
+    public void testProgressToolListedWithoutProgressParam() throws Exception {
+        String response = sendAndReceive("tools/list", null);
+        assertThat(response).as("Should list the progress-test tool").contains("progress-test");
+        assertThat(response).as("Progress must not appear in inputSchema").doesNotContain("\"Progress\"");
+        assertThat(response).as("Progress must not appear as property name").doesNotContain("\"progress\"");
+    }
+
+    @Test
+    public void testProgressNotificationsSent() throws Exception {
+        long toolCallId = nextId.getAndIncrement();
+        CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
+        pendingResponses.put(toolCallId, toolResultFuture);
+
+        String toolCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"progress-test","arguments":{"steps":"3"},"_meta":{"progressToken":"test-token-1"}}}"""
+                .formatted(toolCallId);
+        postToStreamable(toolCallMessage);
+
+        String toolResult = toolResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(toolResult).as("Should receive tool result").isNotNull();
+
+        // Collect all progress notifications (3 steps expected)
+        for (int i = 0; i < 3; i++) {
+            String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            assertThat(notification).as("Should receive progress notification " + (i + 1)).isNotNull();
+
+            JsonObject notificationJson = Json.createReader(new StringReader(notification)).readObject();
+            assertThat(notificationJson.getString("method")).as("Should be notifications/progress")
+                    .isEqualTo(NOTIFICATIONS_PROGRESS);
+            JsonObject params = notificationJson.getJsonObject("params");
+            assertThat(params.getString(PROGRESS_TOKEN)).as("Token should match").isEqualTo("test-token-1");
+            assertThat(params.getJsonNumber("total").intValue()).as("Total should be 3").isEqualTo(3);
+            assertThat(params.getJsonNumber("progress").intValue()).as("Progress should be " + (i + 1))
+                    .isEqualTo(i + 1);
+        }
+
+        JsonObject resultJson = Json.createReader(new StringReader(toolResult)).readObject();
+        assertThat(resultJson.containsKey("result")).as("Should contain result").isTrue();
+        JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
+        assertThat(content.getJsonObject(0).getString("text")).as("Should confirm completion").contains("Completed 3 steps");
+    }
+
+    @Test
+    public void testProgressNotificationWithMessage() throws Exception {
+        long toolCallId = nextId.getAndIncrement();
+        CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
+        pendingResponses.put(toolCallId, toolResultFuture);
+
+        String toolCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"progress-notification-test","arguments":{},"_meta":{"progressToken":"msg-token"}}}"""
+                .formatted(toolCallId);
+        postToStreamable(toolCallMessage);
+
+        String toolResult = toolResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(toolResult).as("Should receive tool result").isNotNull();
+
+        String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(notification).as("Should receive progress notification").isNotNull();
+
+        JsonObject notificationJson = Json.createReader(new StringReader(notification)).readObject();
+        assertThat(notificationJson.getString("method")).as("Should be notifications/progress")
+                .isEqualTo(NOTIFICATIONS_PROGRESS);
+        JsonObject params = notificationJson.getJsonObject("params");
+        assertThat(params.getString(PROGRESS_TOKEN)).as("Token should match").isEqualTo("msg-token");
+        assertThat(params.getJsonNumber("progress").intValue()).as("Progress should be 50").isEqualTo(50);
+        assertThat(params.getJsonNumber("total").intValue()).as("Total should be 100").isEqualTo(100);
+        assertThat(params.getString("message")).as("Message should be present").isEqualTo("Halfway done");
+    }
+
+    @Test
+    public void testProgressNoTokenDoesNotSendNotifications() throws Exception {
+        String response = sendAndReceive("tools/call", Json.createObjectBuilder()
+                .add("name", "progress-no-token")
+                .add("arguments", Json.createObjectBuilder())
+                .build());
+
+        JsonObject resultJson = Json.createReader(new StringReader(response)).readObject();
+        JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
+        assertThat(content.getJsonObject(0).getString("text")).as("Should report no-token").isEqualTo("no-token");
+
+        String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(notification).as("No notifications should be sent without a token").isNull();
+    }
+
+    // ==================== CDI-Injected Progress in Tools ====================
+
+    @Test
+    public void testInjectedProgressToolNotificationsSent() throws Exception {
+        long toolCallId = nextId.getAndIncrement();
+        CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
+        pendingResponses.put(toolCallId, toolResultFuture);
+
+        String toolCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"progress-injected-test","arguments":{"steps":"3"},"_meta":{"progressToken":"injected-token-1"}}}"""
+                .formatted(toolCallId);
+        postToStreamable(toolCallMessage);
+
+        String toolResult = toolResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(toolResult).as("Should receive tool result").isNotNull();
+
+        for (int i = 0; i < 3; i++) {
+            String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            assertThat(notification).as("Should receive progress notification " + (i + 1)).isNotNull();
+
+            JsonObject notificationJson = Json.createReader(new StringReader(notification)).readObject();
+            assertThat(notificationJson.getString("method")).as("Should be notifications/progress")
+                    .isEqualTo(NOTIFICATIONS_PROGRESS);
+            JsonObject params = notificationJson.getJsonObject("params");
+            assertThat(params.getString(PROGRESS_TOKEN)).as("Token should match").isEqualTo("injected-token-1");
+            assertThat(params.getJsonNumber("total").intValue()).as("Total should be 3").isEqualTo(3);
+            assertThat(params.getJsonNumber("progress").intValue()).as("Progress should be " + (i + 1))
+                    .isEqualTo(i + 1);
+        }
+
+        JsonObject resultJson = Json.createReader(new StringReader(toolResult)).readObject();
+        JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
+        assertThat(content.getJsonObject(0).getString("text")).as("Should confirm completion").contains("Completed 3 steps");
+    }
+
+    @Test
+    public void testInjectedProgressToolNoToken() throws Exception {
+        String response = sendAndReceive("tools/call", Json.createObjectBuilder()
+                .add("name", "progress-injected-no-token")
+                .add("arguments", Json.createObjectBuilder())
+                .build());
+
+        JsonObject resultJson = Json.createReader(new StringReader(response)).readObject();
+        JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
+        assertThat(content.getJsonObject(0).getString("text")).as("Should report no-token").isEqualTo("no-token");
+    }
+
+    // ==================== CDI-Injected Progress in Prompts ====================
+
+    @Test
+    public void testInjectedProgressPromptNotificationsSent() throws Exception {
+        long promptCallId = nextId.getAndIncrement();
+        CompletableFuture<String> promptResultFuture = new CompletableFuture<>();
+        pendingResponses.put(promptCallId, promptResultFuture);
+
+        String promptCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"prompts/get","params":{"name":"progress-prompt","arguments":{"name":"WildFly"},"_meta":{"progressToken":"prompt-token"}}}"""
+                .formatted(promptCallId);
+        postToStreamable(promptCallMessage);
+
+        String promptResult = promptResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(promptResult).as("Should receive prompt result").isNotNull();
+
+        String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(notification).as("Should receive progress notification from prompt").isNotNull();
+
+        JsonObject notificationJson = Json.createReader(new StringReader(notification)).readObject();
+        assertThat(notificationJson.getString("method")).as("Should be notifications/progress")
+                .isEqualTo(NOTIFICATIONS_PROGRESS);
+        JsonObject params = notificationJson.getJsonObject("params");
+        assertThat(params.getString(PROGRESS_TOKEN)).as("Token should match").isEqualTo("prompt-token");
+        assertThat(params.getJsonNumber("progress").intValue()).as("Progress should be 1").isEqualTo(1);
+        assertThat(params.getJsonNumber("total").intValue()).as("Total should be 1").isEqualTo(1);
+        assertThat(params.getString("message")).as("Message should be present").isEqualTo("Generating greeting");
+
+        JsonObject resultJson = Json.createReader(new StringReader(promptResult)).readObject();
+        JsonArray messages = resultJson.getJsonObject("result").getJsonArray("messages");
+        String text = messages.getJsonObject(0).getJsonObject("content").getString("text");
+        assertThat(text).as("Should contain greeting").contains("Hello, WildFly!");
+    }
+
+    // ==================== CDI-Injected Progress in Resource Templates ====================
+
+    @Test
+    public void testInjectedProgressResourceTemplateNotificationsSent() throws Exception {
+        long readCallId = nextId.getAndIncrement();
+        CompletableFuture<String> readResultFuture = new CompletableFuture<>();
+        pendingResponses.put(readCallId, readResultFuture);
+
+        String readCallMessage = """
+                {"jsonrpc":"2.0","id":%d,"method":"resources/read","params":{"uri":"test://progress/42","_meta":{"progressToken":"resource-token"}}}"""
+                .formatted(readCallId);
+        postToStreamable(readCallMessage);
+
+        String readResult = readResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(readResult).as("Should receive resource result").isNotNull();
+
+        String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(notification).as("Should receive progress notification from resource template").isNotNull();
+
+        JsonObject notificationJson = Json.createReader(new StringReader(notification)).readObject();
+        assertThat(notificationJson.getString("method")).as("Should be notifications/progress")
+                .isEqualTo(NOTIFICATIONS_PROGRESS);
+        JsonObject params = notificationJson.getJsonObject("params");
+        assertThat(params.getString(PROGRESS_TOKEN)).as("Token should match").isEqualTo("resource-token");
+        assertThat(params.getJsonNumber("progress").intValue()).as("Progress should be 1").isEqualTo(1);
+        assertThat(params.getJsonNumber("total").intValue()).as("Total should be 1").isEqualTo(1);
+        assertThat(params.getString("message")).as("Message should be present").isEqualTo("Loading resource");
+
+        JsonObject resultJson = Json.createReader(new StringReader(readResult)).readObject();
+        JsonArray contents = resultJson.getJsonObject("result").getJsonArray("contents");
+        String text = contents.getJsonObject(0).getString("text");
+        assertThat(text).as("Should contain resource data").isEqualTo("data-for-42");
+    }
+}

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/ProgressIntegrationTestCase.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/ProgressIntegrationTestCase.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.StringReader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -19,9 +20,14 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Integration tests for MCP progress notifications, including CDI-injected Progress.
+ * Integration tests for MCP progress notifications.
+ *
+ * <p>Tool-based tests are parameterized to run against both method-parameter injection
+ * ({@link TestMCPProgressTool}) and CDI injection ({@link TestMCPInjectedProgress}).</p>
  */
 public class ProgressIntegrationTestCase extends AbstractMCPIntegrationTestCase {
 
@@ -36,31 +42,59 @@ public class ProgressIntegrationTestCase extends AbstractMCPIntegrationTestCase 
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    // ==================== Method Parameter Progress (tools only) ====================
+    // ==================== Method sources ====================
 
-    @Test
-    public void testProgressToolListedWithoutProgressParam() throws Exception {
-        String response = sendAndReceive("tools/list", null);
-        assertThat(response).as("Should list the progress-test tool").contains("progress-test");
-        assertThat(response).as("Progress must not appear in inputSchema").doesNotContain("\"Progress\"");
-        assertThat(response).as("Progress must not appear as property name").doesNotContain("\"progress\"");
+    static Stream<String> progressTrackerToolNames() {
+        return Stream.of("progress-test", "progress-injected-test");
     }
 
-    @Test
-    public void testProgressNotificationsSent() throws Exception {
+    static Stream<String> progressNotificationToolNames() {
+        return Stream.of("progress-notification-test", "progress-injected-notification-test");
+    }
+
+    static Stream<String> progressNoTokenToolNames() {
+        return Stream.of("progress-no-token", "progress-injected-no-token");
+    }
+
+    // ==================== Progress tool schema ====================
+
+    @ParameterizedTest
+    @MethodSource("progressTrackerToolNames")
+    public void testProgressToolListedWithoutProgressParam(String toolName) throws Exception {
+        String response = sendAndReceive("tools/list", null);
+        assertThat(response).as("Should list the %s tool", toolName).contains(toolName);
+
+        JsonObject json = Json.createReader(new StringReader(response)).readObject();
+        JsonArray tools = json.getJsonObject("result").getJsonArray("tools");
+        JsonObject progressTool = null;
+        for (int i = 0; i < tools.size(); i++) {
+            if (toolName.equals(tools.getJsonObject(i).getString("name"))) {
+                progressTool = tools.getJsonObject(i);
+                break;
+            }
+        }
+        assertThat(progressTool).as("%s tool should be present", toolName).isNotNull();
+        JsonObject properties = progressTool.getJsonObject("inputSchema").getJsonObject("properties");
+        assertThat(properties.containsKey("progress")).as("%s should not expose progress in schema", toolName).isFalse();
+    }
+
+    // ==================== Progress tracker notifications ====================
+
+    @ParameterizedTest
+    @MethodSource("progressTrackerToolNames")
+    public void testProgressNotificationsSent(String toolName) throws Exception {
         long toolCallId = nextId.getAndIncrement();
         CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
         pendingResponses.put(toolCallId, toolResultFuture);
 
         String toolCallMessage = """
-                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"progress-test","arguments":{"steps":"3"},"_meta":{"progressToken":"test-token-1"}}}"""
-                .formatted(toolCallId);
+                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"%s","arguments":{"steps":"3"},"_meta":{"progressToken":"test-token-1"}}}"""
+                .formatted(toolCallId, toolName);
         postToStreamable(toolCallMessage);
 
         String toolResult = toolResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertThat(toolResult).as("Should receive tool result").isNotNull();
 
-        // Collect all progress notifications (3 steps expected)
         for (int i = 0; i < 3; i++) {
             String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             assertThat(notification).as("Should receive progress notification " + (i + 1)).isNotNull();
@@ -81,15 +115,18 @@ public class ProgressIntegrationTestCase extends AbstractMCPIntegrationTestCase 
         assertThat(content.getJsonObject(0).getString("text")).as("Should confirm completion").contains("Completed 3 steps");
     }
 
-    @Test
-    public void testProgressNotificationWithMessage() throws Exception {
+    // ==================== Progress notification with message ====================
+
+    @ParameterizedTest
+    @MethodSource("progressNotificationToolNames")
+    public void testProgressNotificationWithMessage(String toolName) throws Exception {
         long toolCallId = nextId.getAndIncrement();
         CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
         pendingResponses.put(toolCallId, toolResultFuture);
 
         String toolCallMessage = """
-                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"progress-notification-test","arguments":{},"_meta":{"progressToken":"msg-token"}}}"""
-                .formatted(toolCallId);
+                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"%s","arguments":{},"_meta":{"progressToken":"msg-token"}}}"""
+                .formatted(toolCallId, toolName);
         postToStreamable(toolCallMessage);
 
         String toolResult = toolResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -108,10 +145,13 @@ public class ProgressIntegrationTestCase extends AbstractMCPIntegrationTestCase 
         assertThat(params.getString("message")).as("Message should be present").isEqualTo("Halfway done");
     }
 
-    @Test
-    public void testProgressNoTokenDoesNotSendNotifications() throws Exception {
+    // ==================== Progress without token ====================
+
+    @ParameterizedTest
+    @MethodSource("progressNoTokenToolNames")
+    public void testProgressNoTokenDoesNotSendNotifications(String toolName) throws Exception {
         String response = sendAndReceive("tools/call", Json.createObjectBuilder()
-                .add("name", "progress-no-token")
+                .add("name", toolName)
                 .add("arguments", Json.createObjectBuilder())
                 .build());
 
@@ -121,53 +161,6 @@ public class ProgressIntegrationTestCase extends AbstractMCPIntegrationTestCase 
 
         String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertThat(notification).as("No notifications should be sent without a token").isNull();
-    }
-
-    // ==================== CDI-Injected Progress in Tools ====================
-
-    @Test
-    public void testInjectedProgressToolNotificationsSent() throws Exception {
-        long toolCallId = nextId.getAndIncrement();
-        CompletableFuture<String> toolResultFuture = new CompletableFuture<>();
-        pendingResponses.put(toolCallId, toolResultFuture);
-
-        String toolCallMessage = """
-                {"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"progress-injected-test","arguments":{"steps":"3"},"_meta":{"progressToken":"injected-token-1"}}}"""
-                .formatted(toolCallId);
-        postToStreamable(toolCallMessage);
-
-        String toolResult = toolResultFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        assertThat(toolResult).as("Should receive tool result").isNotNull();
-
-        for (int i = 0; i < 3; i++) {
-            String notification = serverInitiatedMessages.poll(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            assertThat(notification).as("Should receive progress notification " + (i + 1)).isNotNull();
-
-            JsonObject notificationJson = Json.createReader(new StringReader(notification)).readObject();
-            assertThat(notificationJson.getString("method")).as("Should be notifications/progress")
-                    .isEqualTo(NOTIFICATIONS_PROGRESS);
-            JsonObject params = notificationJson.getJsonObject("params");
-            assertThat(params.getString(PROGRESS_TOKEN)).as("Token should match").isEqualTo("injected-token-1");
-            assertThat(params.getJsonNumber("total").intValue()).as("Total should be 3").isEqualTo(3);
-            assertThat(params.getJsonNumber("progress").intValue()).as("Progress should be " + (i + 1))
-                    .isEqualTo(i + 1);
-        }
-
-        JsonObject resultJson = Json.createReader(new StringReader(toolResult)).readObject();
-        JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
-        assertThat(content.getJsonObject(0).getString("text")).as("Should confirm completion").contains("Completed 3 steps");
-    }
-
-    @Test
-    public void testInjectedProgressToolNoToken() throws Exception {
-        String response = sendAndReceive("tools/call", Json.createObjectBuilder()
-                .add("name", "progress-injected-no-token")
-                .add("arguments", Json.createObjectBuilder())
-                .build());
-
-        JsonObject resultJson = Json.createReader(new StringReader(response)).readObject();
-        JsonArray content = resultJson.getJsonObject("result").getJsonArray("content");
-        assertThat(content.getJsonObject(0).getString("text")).as("Should report no-token").isEqualTo("no-token");
     }
 
     // ==================== CDI-Injected Progress in Prompts ====================

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPInjectedProgress.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPInjectedProgress.java
@@ -39,6 +39,19 @@ public class TestMCPInjectedProgress {
         return "Completed " + steps + " steps";
     }
 
+    @Tool(name = "progress-injected-notification-test", description = "Tests individual progress notifications via CDI-injected Progress")
+    String progressNotificationTest() {
+        if (progress.token().isPresent()) {
+            progress.notificationBuilder()
+                    .setProgress(50)
+                    .setTotal(100)
+                    .setMessage("Halfway done")
+                    .build()
+                    .sendAndForget();
+        }
+        return "Done";
+    }
+
     @Tool(name = "progress-injected-no-token", description = "Tests injected progress when no token is provided")
     String progressNoToken() {
         return progress.token().isPresent() ? "has-token" : "no-token";

--- a/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPInjectedProgress.java
+++ b/testsuite/mcp/src/test/java/org/wildfly/ai/test/mcp/TestMCPInjectedProgress.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.test.mcp;
+
+import jakarta.inject.Inject;
+
+import org.mcpjava.server.content.TextContent;
+import org.mcpjava.server.progress.Progress;
+import org.mcpjava.server.progress.ProgressTracker;
+import org.mcpjava.server.prompts.Prompt;
+import org.mcpjava.server.prompts.PromptArg;
+import org.mcpjava.server.prompts.PromptResponse;
+import org.mcpjava.server.resources.ResourceContents;
+import org.mcpjava.server.resources.ResourceTemplate;
+import org.mcpjava.server.resources.ResourceTemplateArg;
+import org.mcpjava.server.resources.TextResourceContents;
+import org.mcpjava.server.tools.Tool;
+import org.mcpjava.server.tools.ToolArg;
+
+import static org.mcpjava.server.Role.USER;
+
+public class TestMCPInjectedProgress {
+
+    @Inject
+    Progress progress;
+
+    @Tool(name = "progress-injected-test", description = "Tests progress reporting via CDI-injected Progress")
+    String progressTest(@ToolArg(description = "Number of steps to simulate") int steps) {
+        if (progress.token().isPresent()) {
+            ProgressTracker tracker = progress.trackerBuilder()
+                    .setTotal(steps)
+                    .build();
+            for (int i = 0; i < steps; i++) {
+                tracker.advanceAndForget();
+            }
+        }
+        return "Completed " + steps + " steps";
+    }
+
+    @Tool(name = "progress-injected-no-token", description = "Tests injected progress when no token is provided")
+    String progressNoToken() {
+        return progress.token().isPresent() ? "has-token" : "no-token";
+    }
+
+    @Prompt(name = "progress-prompt", description = "A prompt that sends progress notifications")
+    PromptResponse progressPrompt(@PromptArg(description = "Name") String name) {
+        if (progress.token().isPresent()) {
+            progress.notificationBuilder()
+                    .setProgress(1)
+                    .setTotal(1)
+                    .setMessage("Generating greeting")
+                    .build()
+                    .sendAndForget();
+        }
+        return PromptResponse.of(USER, TextContent.of("Hello, " + name + "!"));
+    }
+
+    @ResourceTemplate(uriTemplate = "test://progress/{id}", mimeType = "text/plain", name = "progress-resource")
+    ResourceContents progressResource(@ResourceTemplateArg(name = "id") String id) {
+        if (progress.token().isPresent()) {
+            progress.notificationBuilder()
+                    .setProgress(1)
+                    .setTotal(1)
+                    .setMessage("Loading resource")
+                    .build()
+                    .sendAndForget();
+        }
+        return TextResourceContents.of("test://progress/" + id, "data-for-" + id);
+    }
+}

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
@@ -27,15 +27,14 @@ public interface MCPLogger extends BasicLogger {
     void unexpectedError(@Cause Throwable cause);
 
     @LogMessage(level = WARN)
-    @Message(id = 2, value = "Vetoing user-defined ElicitationSender bean %s — ElicitationSender is provided by the MCP subsystem and must not be overridden by deployments")
-    void vetoedUserElicitationSender(String className);
+    @Message(id = 2, value = "Vetoing user-defined %s bean %s as this bean is provided by the MCP subsystem and must not be overridden by deployments")
+    void vetoedCDIBean(String interfaceName, String className);
 
     @Message(id = 3, value = "ElicitationSender is not available outside of an MCP invocation context")
     IllegalStateException elicitationSenderNotAvailable();
 
-    @LogMessage(level = WARN)
-    @Message(id = 4, value = "Vetoing user-defined Progress bean %s — Progress is provided by the MCP subsystem and must not be overridden by deployments")
-    void vetoedUserProgress(String className);
+    @Message(id = 4, value = "Deployment must not produce %s bean — it is provided by the MCP subsystem")
+    IllegalStateException deploymentMustNotProduceBean(String className);
 
     @Message(id = 5, value = "Progress is not available outside of an MCP invocation context")
     IllegalStateException progressNotAvailable();

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/MCPLogger.java
@@ -32,4 +32,11 @@ public interface MCPLogger extends BasicLogger {
 
     @Message(id = 3, value = "ElicitationSender is not available outside of an MCP invocation context")
     IllegalStateException elicitationSenderNotAvailable();
+
+    @LogMessage(level = WARN)
+    @Message(id = 4, value = "Vetoing user-defined Progress bean %s — Progress is provided by the MCP subsystem and must not be overridden by deployments")
+    void vetoedUserProgress(String className);
+
+    @Message(id = 5, value = "Progress is not available outside of an MCP invocation context")
+    IllegalStateException progressNotAvailable();
 }

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/progress/ProgressBean.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/progress/ProgressBean.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.mcp.injection.progress;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.RequestScoped;
+
+import org.mcpjava.server.progress.Progress;
+import org.mcpjava.server.progress.ProgressNotification;
+import org.mcpjava.server.progress.ProgressToken;
+import org.mcpjava.server.progress.ProgressTracker;
+
+import static org.wildfly.extension.mcp.injection.MCPLogger.ROOT_LOGGER;
+
+@RequestScoped
+public class ProgressBean implements Progress {
+
+    @Override
+    public Optional<ProgressToken> token() {
+        return delegate().token();
+    }
+
+    @Override
+    public ProgressNotification.Builder notificationBuilder() {
+        return delegate().notificationBuilder();
+    }
+
+    @Override
+    public ProgressTracker.Builder trackerBuilder() {
+        return delegate().trackerBuilder();
+    }
+
+    private Progress delegate() {
+        Progress progress = ProgressHolder.get();
+        if (progress == null) {
+            throw ROOT_LOGGER.progressNotAvailable();
+        }
+        return progress;
+    }
+}

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/progress/ProgressHolder.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/progress/ProgressHolder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.mcp.injection.progress;
+
+import org.mcpjava.server.progress.Progress;
+
+public final class ProgressHolder {
+
+    private static final ThreadLocal<Progress> CURRENT = new ThreadLocal<>();
+
+    private ProgressHolder() {
+    }
+
+    public static void set(Progress progress) {
+        CURRENT.set(progress);
+    }
+
+    public static Progress get() {
+        return CURRENT.get();
+    }
+
+    public static void remove() {
+        CURRENT.remove();
+    }
+}

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPPortableExtension.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPPortableExtension.java
@@ -121,44 +121,40 @@ public class MCPPortableExtension implements Extension {
 
     public <T extends ElicitationSender> void vetoUserElicitationSender(@Observes ProcessAnnotatedType<T> event) {
         if (!ElicitationSenderBean.class.equals(event.getAnnotatedType().getJavaClass())) {
-            ROOT_LOGGER.vetoedUserElicitationSender(event.getAnnotatedType().getJavaClass().getName());
+            ROOT_LOGGER.vetoedCDIBean(ElicitationSender.class.getName(), event.getAnnotatedType().getJavaClass().getName());
             event.veto();
         }
     }
 
     public <X> void vetoUserElicitationSenderProducer(@Observes ProcessProducerMethod<ElicitationSender, X> event) {
         String name = event.getAnnotatedProducerMethod().getJavaMember().toGenericString();
-        ROOT_LOGGER.vetoedUserElicitationSender(name);
-        event.addDefinitionError(new IllegalStateException(
-                "Deployment must not produce ElicitationSender — it is provided by the MCP subsystem: " + name));
+        ROOT_LOGGER.vetoedCDIBean(ElicitationSender.class.getName(), name);
+        event.addDefinitionError(ROOT_LOGGER.deploymentMustNotProduceBean(name));
     }
 
     public <X> void vetoUserElicitationSenderField(@Observes ProcessProducerField<ElicitationSender, X> event) {
         String name = event.getAnnotatedProducerField().getJavaMember().toGenericString();
-        ROOT_LOGGER.vetoedUserElicitationSender(name);
-        event.addDefinitionError(new IllegalStateException(
-                "Deployment must not produce ElicitationSender — it is provided by the MCP subsystem: " + name));
+        ROOT_LOGGER.vetoedCDIBean(ElicitationSender.class.getName(), name);
+        event.addDefinitionError(ROOT_LOGGER.deploymentMustNotProduceBean(name));
     }
 
     public <T extends Progress> void vetoUserProgress(@Observes ProcessAnnotatedType<T> event) {
         if (!ProgressBean.class.equals(event.getAnnotatedType().getJavaClass())) {
-            ROOT_LOGGER.vetoedUserProgress(event.getAnnotatedType().getJavaClass().getName());
+            ROOT_LOGGER.vetoedCDIBean(Progress.class.getName(), event.getAnnotatedType().getJavaClass().getName());
             event.veto();
         }
     }
 
     public <X> void vetoUserProgressProducer(@Observes ProcessProducerMethod<Progress, X> event) {
         String name = event.getAnnotatedProducerMethod().getJavaMember().toGenericString();
-        ROOT_LOGGER.vetoedUserProgress(name);
-        event.addDefinitionError(new IllegalStateException(
-                "Deployment must not produce Progress — it is provided by the MCP subsystem: " + name));
+        ROOT_LOGGER.vetoedCDIBean(Progress.class.getName(), name);
+        event.addDefinitionError(ROOT_LOGGER.deploymentMustNotProduceBean(name));
     }
 
     public <X> void vetoUserProgressField(@Observes ProcessProducerField<Progress, X> event) {
         String name = event.getAnnotatedProducerField().getJavaMember().toGenericString();
-        ROOT_LOGGER.vetoedUserProgress(name);
-        event.addDefinitionError(new IllegalStateException(
-                "Deployment must not produce Progress — it is provided by the MCP subsystem: " + name));
+        ROOT_LOGGER.vetoedCDIBean(Progress.class.getName(), name);
+        event.addDefinitionError(ROOT_LOGGER.deploymentMustNotProduceBean(name));
     }
 
     private void updateAnnotations(Map<Class<?>, Set<AnnotationLiteral>> beanClasses, Class<?> clazz, AnnotationLiteral... annotations) {

--- a/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPPortableExtension.java
+++ b/wildfly-mcp/injection/src/main/java/org/wildfly/extension/mcp/injection/tool/MCPPortableExtension.java
@@ -17,8 +17,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.mcpjava.server.progress.Progress;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.extension.mcp.injection.elicitation.ElicitationSenderBean;
+import org.wildfly.extension.mcp.injection.progress.ProgressBean;
 import org.wildfly.mcp.api.elicitation.ElicitationSender;
 
 import static org.wildfly.extension.mcp.injection.MCPLogger.ROOT_LOGGER;
@@ -114,6 +116,7 @@ public class MCPPortableExtension implements Extension {
             ROOT_LOGGER.debugf("%s should be discoverable by CDI", bean.getKey().getName());
         }
         atd.addAnnotatedType(ElicitationSenderBean.class, "elicitation-sender-bean");
+        atd.addAnnotatedType(ProgressBean.class, "progress-bean");
     }
 
     public <T extends ElicitationSender> void vetoUserElicitationSender(@Observes ProcessAnnotatedType<T> event) {
@@ -135,6 +138,27 @@ public class MCPPortableExtension implements Extension {
         ROOT_LOGGER.vetoedUserElicitationSender(name);
         event.addDefinitionError(new IllegalStateException(
                 "Deployment must not produce ElicitationSender — it is provided by the MCP subsystem: " + name));
+    }
+
+    public <T extends Progress> void vetoUserProgress(@Observes ProcessAnnotatedType<T> event) {
+        if (!ProgressBean.class.equals(event.getAnnotatedType().getJavaClass())) {
+            ROOT_LOGGER.vetoedUserProgress(event.getAnnotatedType().getJavaClass().getName());
+            event.veto();
+        }
+    }
+
+    public <X> void vetoUserProgressProducer(@Observes ProcessProducerMethod<Progress, X> event) {
+        String name = event.getAnnotatedProducerMethod().getJavaMember().toGenericString();
+        ROOT_LOGGER.vetoedUserProgress(name);
+        event.addDefinitionError(new IllegalStateException(
+                "Deployment must not produce Progress — it is provided by the MCP subsystem: " + name));
+    }
+
+    public <X> void vetoUserProgressField(@Observes ProcessProducerField<Progress, X> event) {
+        String name = event.getAnnotatedProducerField().getJavaMember().toGenericString();
+        ROOT_LOGGER.vetoedUserProgress(name);
+        event.addDefinitionError(new IllegalStateException(
+                "Deployment must not produce Progress — it is provided by the MCP subsystem: " + name));
     }
 
     private void updateAnnotations(Map<Class<?>, Set<AnnotationLiteral>> beanClasses, Class<?> clazz, AnnotationLiteral... annotations) {

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPServerUtils.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPServerUtils.java
@@ -28,9 +28,12 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
+import org.mcpjava.server.progress.ProgressToken;
 import org.wildfly.extension.mcp.api.MCPConnection;
 import org.wildfly.extension.mcp.api.Responder;
+import org.wildfly.extension.mcp.injection.MCPFieldNames;
 import org.wildfly.extension.mcp.injection.elicitation.ElicitationSenderHolder;
+import org.wildfly.extension.mcp.injection.progress.ProgressHolder;
 import org.wildfly.extension.mcp.injection.tool.ArgumentMetadata;
 
 /**
@@ -110,7 +113,20 @@ final class MCPServerUtils {
         return ret;
     }
 
-    static void runWithCDIContext(MCPConnection connection, Responder responder, Runnable task) {
+    static ProgressToken extractProgressToken(JsonObject params) {
+        JsonObject meta = params != null ? params.getJsonObject(MCPFieldNames.META) : null;
+        if (meta != null && meta.containsKey(MCPFieldNames.PROGRESS_TOKEN)) {
+            JsonValue tokenVal = meta.get(MCPFieldNames.PROGRESS_TOKEN);
+            if (tokenVal.getValueType() == ValueType.STRING) {
+                return new ProgressTokenImpl(((JsonString) tokenVal).getString());
+            } else if (tokenVal.getValueType() == ValueType.NUMBER) {
+                return new ProgressTokenImpl(((jakarta.json.JsonNumber) tokenVal).longValue());
+            }
+        }
+        return null;
+    }
+
+    static void runWithCDIContext(MCPConnection connection, Responder responder, ProgressToken progressToken, Runnable task) {
         RequestContextController rcc = null;
         try {
             rcc = CDI.current().select(RequestContextController.class).get();
@@ -121,9 +137,11 @@ final class MCPServerUtils {
         try {
             ElicitationSenderHolder.set(new ElicitationSenderImpl(
                     connection.pendingRequests(), responder, connection.initializeRequest()));
+            ProgressHolder.set(new ProgressImpl(progressToken, responder));
             try {
                 task.run();
             } finally {
+                ProgressHolder.remove();
                 ElicitationSenderHolder.remove();
             }
         } finally {

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PromptMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/PromptMessageHandler.java
@@ -130,7 +130,7 @@ public class PromptMessageHandler {
         final ClassLoader prevCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, () -> {
+            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, MCPServerUtils.extractProgressToken(params), () -> {
                 try {
                     MethodMetadata methodMetadata = metadata.method();
                     Class<?> clazz = classLoader.loadClass(methodMetadata.declaringClassName());

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceMessageHandler.java
@@ -199,7 +199,7 @@ public class ResourceMessageHandler {
         final ClassLoader prevCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, () -> {
+            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, MCPServerUtils.extractProgressToken(params), () -> {
                 try {
                     MethodMetadata methodMetadata = metadata.method();
                     Class<?> clazz = classLoader.loadClass(methodMetadata.declaringClassName());

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceTemplateMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ResourceTemplateMessageHandler.java
@@ -125,7 +125,7 @@ public class ResourceTemplateMessageHandler {
         final ClassLoader prevCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, () -> {
+            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, MCPServerUtils.extractProgressToken(params), () -> {
                 try {
                     MethodMetadata methodMetadata = metadata.method();
                     Class<?> clazz = classLoader.loadClass(methodMetadata.declaringClassName());

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/ToolMessageHandler.java
@@ -14,13 +14,11 @@ import static org.wildfly.extension.mcp.injection.MCPFieldNames.DESCRIPTION;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.DESTRUCTIVE_HINT;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.IDEMPOTENT_HINT;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.INPUT_SCHEMA;
-import static org.wildfly.extension.mcp.injection.MCPFieldNames.META;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.NAME;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.NEXT_CURSOR;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.OPEN_WORLD_HINT;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.OUTPUT_SCHEMA;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.PARAMS;
-import static org.wildfly.extension.mcp.injection.MCPFieldNames.PROGRESS_TOKEN;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.READ_ONLY_HINT;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.STRUCTURED_CONTENT;
 import static org.wildfly.extension.mcp.injection.MCPFieldNames.TITLE;
@@ -47,9 +45,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
-import jakarta.json.JsonValue.ValueType;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -78,6 +74,7 @@ import org.wildfly.extension.mcp.api.Responder;
 import org.wildfly.extension.mcp.injection.WildFlyMCPRegistry;
 import org.wildfly.mcp.api.elicitation.ElicitationSender;
 import org.wildfly.extension.mcp.injection.elicitation.ElicitationSenderHolder;
+import org.wildfly.extension.mcp.injection.progress.ProgressHolder;
 import org.wildfly.extension.mcp.injection.tool.ArgumentMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPFeatureMetadata;
 import org.wildfly.extension.mcp.injection.tool.MCPTool;
@@ -344,17 +341,7 @@ public class ToolMessageHandler {
                 args.put(key, arguments.get(key));
             }
         }
-        ProgressToken progressToken = null;
-        JsonObject meta = params.getJsonObject(META);
-        if (meta != null && meta.containsKey(PROGRESS_TOKEN)) {
-            JsonValue tokenVal = meta.get(PROGRESS_TOKEN);
-            if (tokenVal.getValueType() == ValueType.STRING) {
-                progressToken = new ProgressTokenImpl(((JsonString) tokenVal).getString());
-            } else if (tokenVal.getValueType() == ValueType.NUMBER) {
-                progressToken = new ProgressTokenImpl(((jakarta.json.JsonNumber) tokenVal).longValue());
-            }
-        }
-        final ProgressToken finalProgressToken = progressToken;
+        final ProgressToken finalProgressToken = MCPServerUtils.extractProgressToken(params);
         final MCPFeatureMetadata metadata = registry.getTool(toolName);
         if (metadata == null) {
             responder.sendError(id, INVALID_PARAMS, ROOT_LOGGER.invalidToolName(toolName));
@@ -363,14 +350,13 @@ public class ToolMessageHandler {
         final ClassLoader prevCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, () -> {
+            connection.task(executorService.submit(() -> runWithCDIContext(connection, responder, finalProgressToken, () -> {
                 try {
                     MethodMetadata methodMetadata = metadata.method();
                     Class<?> clazz = classLoader.loadClass(methodMetadata.declaringClassName());
                     Instance<?> beanInstance = CDI.current().select(clazz, MCPTool.MCPToolLiteral.INSTANCE);
                     Object result = null;
-                    ElicitationSender elicitationSender = ElicitationSenderHolder.get();
-                    Object[] builtArgs = buildArguments(metadata, args, mapper, elicitationSender, responder, finalProgressToken);
+                    Object[] builtArgs = buildArguments(metadata, args, mapper);
                     if (beanInstance.isResolvable()) {
                         ROOT_LOGGER.debugf("The Singleton instance of the tool %s has been found", toolName);
                         try {
@@ -441,15 +427,12 @@ public class ToolMessageHandler {
 
     /**
      * Like {@link #prepareArguments} but additionally injects framework-managed parameters
-     * such as {@link ElicitationSender} based on the declared argument type.
+     * such as {@link ElicitationSender} and {@link Progress} based on the declared argument type.
      */
     private Object[] buildArguments(
             MCPFeatureMetadata metadata,
             Map<String, JsonValue> jsonArgs,
-            ObjectMapper objectMapper,
-            ElicitationSender elicitationSender,
-            Responder responder,
-            ProgressToken progressToken) throws MCPException {
+            ObjectMapper objectMapper) throws MCPException {
         if (metadata.arguments().isEmpty()) {
             return new Object[0];
         }
@@ -457,9 +440,9 @@ public class ToolMessageHandler {
         int idx = 0;
         for (ArgumentMetadata arg : metadata.arguments()) {
             if (arg.type() instanceof Class<?> clazz && ElicitationSender.class.isAssignableFrom(clazz)) {
-                ret[idx] = elicitationSender;
+                ret[idx] = ElicitationSenderHolder.get();
             } else if (arg.type() instanceof Class<?> clazz && Progress.class.isAssignableFrom(clazz)) {
-                ret[idx] = new ProgressImpl(progressToken, responder);
+                ret[idx] = ProgressHolder.get();
             } else {
                 JsonValue val = jsonArgs.get(arg.name());
                 if (val == null && arg.required()) {


### PR DESCRIPTION
## Summary
- Make `Progress` injectable via `@Inject` (CDI) following the same pattern as `ElicitationSender` (#329): `ProgressHolder` (ThreadLocal) + `ProgressBean` (`@RequestScoped` delegate) + veto logic in `MCPPortableExtension`
- Support `Progress` in **all** MCP feature types (tools, prompts, resources, resource templates) — not just tools
- Extract `progressToken` parsing into a shared `MCPServerUtils.extractProgressToken()` utility, used by all message handlers

Resolves #330

## Test plan
- [x] Existing method-parameter progress tests continue to pass (moved to dedicated `ProgressIntegrationTestCase`)
- [x] Tool-based tests are parameterized to run against both method-parameter (`TestMCPProgressTool`) and CDI-injected (`TestMCPInjectedProgress`) variants
- [x] New tests verify CDI-injected `Progress` works in prompts and resource templates
- [x] All 77 MCP integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)