### PR TITLE
fix(mcp): verify protocolVersion in initialize message

### DIFF
--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPLogger.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/MCPLogger.java
@@ -10,6 +10,7 @@ import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Set;
 
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -182,4 +183,7 @@ public interface MCPLogger extends BasicLogger {
     @Message(id = 44, value = "Unhandled content block type: %s")
     @LogMessage(level = WARN)
     void warnUnhandledContentBlockType(String className);
+
+    @Message(id = 45, value = "Unsupported protocol version: %s (supported: %s)")
+    String unsupportedProtocolVersion(String actual, Set<String> supported);
 }

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/MCPMethods.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/api/MCPMethods.java
@@ -4,12 +4,15 @@
  */
 package org.wildfly.extension.mcp.api;
 
+import java.util.Set;
+
 /**
  * MCP protocol method names and version constant.
  */
 public final class MCPMethods {
 
     public static final String PROTOCOL_VERSION = "2025-11-25";
+    public static final Set<String> SUPPORTED_PROTOCOL_VERSIONS = Set.of(PROTOCOL_VERSION, "2025-06-18", "2025-03-26");
     public static final String INITIALIZE = "initialize";
     public static final String NOTIFICATIONS_INITIALIZED = "notifications/initialized";
     public static final String NOTIFICATIONS_CANCEL = "notifications/cancelled";

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPMessageHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/MCPMessageHandler.java
@@ -221,7 +221,16 @@ public class MCPMessageHandler {
             return;
         }
         // TODO schema validation?
-        if (connection.initialize(decodeInitializeRequest(params))) {
+        InitializeRequest initializeRequest = decodeInitializeRequest(params);
+        if (!SUPPORTED_PROTOCOL_VERSIONS.contains(initializeRequest.protocolVersion())) {
+            ROOT_LOGGER.invalidProtocolVersion(PROTOCOL_VERSION, initializeRequest.protocolVersion());
+            String msg = ROOT_LOGGER.unsupportedProtocolVersion(initializeRequest.protocolVersion(), SUPPORTED_PROTOCOL_VERSIONS);
+            context.setErrorCode(JsonRPC.INVALID_PARAMS);
+            context.setErrorMessage(msg);
+            responder.sendError(id, JsonRPC.INVALID_PARAMS, msg);
+            return;
+        }
+        if (connection.initialize(initializeRequest)) {
             // The server MUST respond with its own capabilities and information
             responder.sendResult(id, JsonRPC.convertMap(serverInfo));
         } else {

--- a/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/StreamableHttpHandler.java
+++ b/wildfly-mcp/subsystem/src/main/java/org/wildfly/extension/mcp/server/StreamableHttpHandler.java
@@ -9,6 +9,7 @@ import static org.wildfly.extension.mcp.MCPLogger.ROOT_LOGGER;
 import static org.wildfly.extension.mcp.api.ConnectionManager.MCP_PROTOCOL_VERSION_HEADER;
 import static org.wildfly.extension.mcp.api.ConnectionManager.MCP_SESSION_ID_HEADER;
 import static org.wildfly.extension.mcp.api.MCPMethods.PROTOCOL_VERSION;
+import static org.wildfly.extension.mcp.api.MCPMethods.SUPPORTED_PROTOCOL_VERSIONS;
 import static org.wildfly.extension.mcp.server.MCPStreamableConnectionCallBack.JSON_PAYLOAD;
 import static org.wildfly.extension.mcp.server.MCPStreamableConnectionCallBack.SESSION_ID;
 
@@ -91,7 +92,7 @@ public class StreamableHttpHandler implements HttpHandler {
             return;
         }
         String protocolVersion = exchange.getRequestHeaders().getFirst(MCP_PROTOCOL_VERSION_HEADER);
-        if (protocolVersion != null && !PROTOCOL_VERSION.equals(protocolVersion)) {
+        if (protocolVersion != null && !SUPPORTED_PROTOCOL_VERSIONS.contains(protocolVersion)) {
             ROOT_LOGGER.invalidProtocolVersion(PROTOCOL_VERSION, protocolVersion);
             exchange.setStatusCode(400);
             exchange.endExchange();


### PR DESCRIPTION
Validate the client's protocolVersion during the JSON-RPC initialize handshake against a set of supported versions (2025-11-25, 2025-06-18, 2025-03-26). Reject with INVALID_PARAMS if unsupported. Also update the HTTP header check in StreamableHttpHandler to use the same set.

This fixes #346 