### PR TITLE
Add support for GuardRails

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ The feature pack provides 37 Galleon layers organized by functionality. For each
   * `mcp-client-stdio`: MCP Client using the Standard Input/Output (stdio) transport
   * `mcp-client-streable`: MCP Client using the Streamable transport
   * `mcp-server`: MCP Server support for exposing Jakarta EE applications as MCP servers
+* Support for [Guardrails](#guardrails) to validate or rewrite AI service input/output (no dedicated layer - works with any chat model layer already listed above), via `@RegisterAIService` attributes:
+  * `inputGuardrails` / `outputGuardrails`: reference guardrail classes directly
+  * `inputGuardrailNames` / `outputGuardrailNames`: reference named CDI guardrail beans
 * Support for WebAssembly:
   * `wasm`: WebAssembly WASI module support
   
@@ -280,6 +283,31 @@ To get the token associated to a user you can use the following command:
 ```
 curl -X POST http://localhost:8080/realms/myrealm/protocol/openid-connect/token -H 'content-type: application/x-www-form-urlencoded' -d 'client_id=mcp-client&client_secret=UmqLUYjlRbDXZqa6vsiOmonjysIxTL7W' -d 'username=myuser&password=myuser&grant_type=password' | jq --raw-output '.access_token'
 ```
+
+Guardrails
+==========================
+
+The feature pack lets AI services use [LangChain4j Guardrails](https://docs.langchain4j.dev/tutorials/guardrails)
+to validate or rewrite messages going into and coming out of the model. This is provided by
+`langchain4j-cdi`, so it works with any chat model layer already - there is no dedicated Galleon
+layer to provision.
+
+`@RegisterAIService` supports:
+
+* `inputGuardrails` / `outputGuardrails`: `Class<? extends InputGuardrail/OutputGuardrail>[]`,
+  instantiated directly (no CDI needed) - use this when the guardrail has no dependencies of its
+  own.
+* `inputGuardrailNames` / `outputGuardrailNames`: `String[]` referencing `@Named` CDI beans
+  implementing `InputGuardrail`/`OutputGuardrail` - use this when the guardrail needs `@Inject`
+  (for example, to call a moderation service).
+
+A guardrail can reject a request or response (`failure(...)`/`fatal(...)`, surfaced to the caller
+as a `GuardrailException`), or rewrite it transparently (`successWith(...)`).
+
+See the [`guardrails-assistant`](examples/guardrails-assistant) example for a complete
+input-rejection and output-rewriting walkthrough.
+
+
 
 [PROOF OF CONCEPT] WASM Support
 ==========================

--- a/guardrails/README.md
+++ b/guardrails/README.md
@@ -1,0 +1,131 @@
+# Guardrails Example
+
+[LangChain4j Guardrails](https://docs.langchain4j.dev/tutorials/guardrails) let you validate or
+rewrite the messages going into and coming out of an AI service. Support for them comes from
+`langchain4j-cdi` (already a transitive dependency of every `ollama-chat-model` /
+`openai-chat-model` / ... layer) via extra attributes on `@RegisterAIService` - there is no
+separate Galleon layer to provision.
+
+## What it shows
+
+* `ProfanityInputGuardrail` - an `InputGuardrail` that rejects the request *before it reaches the
+  model* if the message contains a disallowed word.
+* `ResponseLengthOutputGuardrail` - an `OutputGuardrail` that *rewrites* the model's answer
+  (truncating it) instead of rejecting it.
+* `Assistant` - wires both in with `@RegisterAIService(chatModelName = "ollama", inputGuardrails =
+  ProfanityInputGuardrail.class, outputGuardrails = ResponseLengthOutputGuardrail.class)`.
+* `GuardrailExceptionMapper` - a JAX-RS `ExceptionMapper` turning the `GuardrailException` thrown
+  by a failed input guardrail into an HTTP 422 response instead of a generic 500.
+
+## Prerequisites
+
+* JDK 17+
+* Maven 3.9+
+* [Ollama](https://ollama.com/) running locally with `llama3.1:8b` pulled:
+
+```shell
+ollama pull llama3.1:8b
+```
+
+## Build and run
+
+Start the application using:
+
+```shell
+mvn wildfly:dev
+```
+
+This provisions a WildFly server with the `ollama-chat-model` layer at the experimental
+stability level and deploys the application. The server remains running in the foreground.
+
+## Trying it out
+
+The REST endpoint is available at:
+
+```text
+http://localhost:8080/guardrails-assistant/api/chat
+```
+
+### Normal request
+
+A normal request passes through to the model:
+
+```shell
+curl -s -X POST http://localhost:8080/guardrails-assistant/api/chat \
+    -H 'Content-Type: text/plain' \
+    -d 'Say hello in one short sentence.'
+```
+
+Example response:
+
+```text
+Hello!
+```
+
+### Blocked input
+
+The input guardrail rejects the request before Ollama is called:
+
+```shell
+curl -i -X POST http://localhost:8080/guardrails-assistant/api/chat \
+    -H 'Content-Type: text/plain' \
+    -d 'You are stupid.'
+```
+
+Example response:
+
+```text
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: text/plain;charset=UTF-8
+
+The guardrail org.wildfly.ai.examples.guardrails.ProfanityInputGuardrail failed with this message:
+The message contains disallowed language ('stupid')
+```
+
+### Long response
+
+The output guardrail rewrites the model response instead of rejecting it:
+
+```shell
+curl -s -X POST http://localhost:8080/guardrails-assistant/api/chat \
+    -H 'Content-Type: text/plain' \
+    -d 'Write a detailed 300-word essay about WildFly application server.'
+```
+
+Example response:
+
+```text
+WildFly is an open-source Java application server ... (truncated by output guardrail)
+```
+
+## Implementation details
+
+The AI service registers the guardrails using `@RegisterAIService`:
+
+```java
+@RegisterAIService(
+        chatModelName = "ollama",
+        inputGuardrails = ProfanityInputGuardrail.class,
+        outputGuardrails = ResponseLengthOutputGuardrail.class
+)
+public interface Assistant {
+}
+```
+
+The input guardrail runs before the request reaches the AI model.
+
+The output guardrail runs after the model generates a response and can either:
+
+* accept the response unchanged,
+* reject it,
+* or rewrite it before returning it to the caller.
+
+## Notes
+
+This example uses simple guardrail implementations for demonstration purposes:
+
+* The input guardrail uses a small deny-list of words.
+* The output guardrail truncates responses longer than the configured maximum length.
+
+In a real application, guardrails can integrate with external moderation services,
+business rules, validation systems, or other application-specific logic.

--- a/guardrails/pom.xml
+++ b/guardrails/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wildfly.generative-ai.examples</groupId>
+    <artifactId>guardrails-assistant</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <name>WildFly AI Feature Pack Example - Guardrails</name>
+    <description>
+        An AI service protected by an input guardrail (rejects disallowed input) and an output
+        guardrail (rewrites the model's response), using LangChain4j's Guardrails support that
+        ships with the wildfly-ai-feature-pack ollama-chat-model layer.
+    </description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly.ai-feature-pack>0.11.0-SNAPSHOT</version.wildfly.ai-feature-pack>
+        <version.wildfly.maven.plugin>6.0.0.Final</version.wildfly.maven.plugin>
+        <version.langchain4j>1.17.0</version.langchain4j>
+        <version.langchain4j.cdi>1.3.4</version.langchain4j.cdi>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>10.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${version.langchain4j}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j.cdi</groupId>
+            <artifactId>langchain4j-cdi-core</artifactId>
+            <version>${version.langchain4j.cdi}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>guardrails-assistant</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
+                <configuration>
+                    <stability>experimental</stability>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                        </feature-pack>
+                        <feature-pack>
+                            <location>org.wildfly.generative-ai:wildfly-ai-feature-pack:${version.wildfly.ai-feature-pack}</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>cdi</layer>
+                        <layer>jaxrs-server</layer>
+                        <layer>management</layer>
+                        <layer>ollama-chat-model</layer>
+                    </layers>
+                    <galleon-options>
+                        <jboss-fork-embedded>true</jboss-fork-embedded>
+                    </galleon-options>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/Assistant.java
+++ b/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/Assistant.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.examples.guardrails;
+
+import dev.langchain4j.cdi.spi.RegisterAIService;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+
+@RegisterAIService(
+        chatModelName = "ollama",
+        inputGuardrails = ProfanityInputGuardrail.class,
+        outputGuardrails = ResponseLengthOutputGuardrail.class
+)
+public interface Assistant {
+
+    @SystemMessage("You are a helpful assistant. Keep answers concise.")
+    String chat(@UserMessage String message);
+}

--- a/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/ChatResource.java
+++ b/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/ChatResource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.examples.guardrails;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/chat")
+public class ChatResource {
+
+    @Inject
+    Assistant assistant;
+
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String chat(String message) {
+        return assistant.chat(message);
+    }
+}

--- a/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/GuardrailExceptionMapper.java
+++ b/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/GuardrailExceptionMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.examples.guardrails;
+
+import dev.langchain4j.guardrail.GuardrailException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * A failed input guardrail (or a fatal output guardrail) surfaces to the caller as a {@link
+ * GuardrailException}. Map it to HTTP 422 instead of a generic 500 so a REST client can tell a
+ * rejected request apart from a real server error.
+ */
+@Provider
+public class GuardrailExceptionMapper implements ExceptionMapper<GuardrailException> {
+
+    @Override
+    public Response toResponse(GuardrailException exception) {
+        return Response.status(422)
+                .type(MediaType.TEXT_PLAIN)
+                .entity(exception.getMessage())
+                .build();
+    }
+}

--- a/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/ProfanityInputGuardrail.java
+++ b/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/ProfanityInputGuardrail.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.examples.guardrails;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Rejects the request before it ever reaches the LLM if the user message contains a word from
+ * the deny-list. Referenced by class from {@link Assistant} via {@code @RegisterAIService(...
+ * inputGuardrails = ProfanityInputGuardrail.class)}.
+ */
+public class ProfanityInputGuardrail implements InputGuardrail {
+
+    private static final List<String> DISALLOWED_WORDS = List.of("idiot", "stupid");
+
+    @Override
+    public InputGuardrailResult validate(UserMessage userMessage) {
+        String text = userMessage.singleText().toLowerCase(Locale.ROOT);
+        for (String word : DISALLOWED_WORDS) {
+            if (text.contains(word)) {
+                return failure("The message contains disallowed language ('" + word + "')");
+            }
+        }
+        return success();
+    }
+}

--- a/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/ResponseLengthOutputGuardrail.java
+++ b/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/ResponseLengthOutputGuardrail.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.examples.guardrails;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
+
+/**
+ * Rewrites the model's response instead of rejecting it, showing that an output guardrail can
+ * transform what is returned to the caller. Referenced by class from {@link Assistant} via
+ * {@code @RegisterAIService(... outputGuardrails = ResponseLengthOutputGuardrail.class)}.
+ */
+public class ResponseLengthOutputGuardrail implements OutputGuardrail {
+
+    private static final int MAX_LENGTH = 500;
+
+    @Override
+    public OutputGuardrailResult validate(AiMessage aiMessage) {
+        String text = aiMessage.text();
+        if (text != null && text.length() > MAX_LENGTH) {
+            return successWith(text.substring(0, MAX_LENGTH) + "... (truncated by output guardrail)");
+        }
+        return success();
+    }
+}

--- a/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/RestApplication.java
+++ b/guardrails/src/main/java/org/wildfly/ai/examples/guardrails/RestApplication.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.ai.examples.guardrails;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class RestApplication extends Application {
+}

--- a/guardrails/src/main/webapp/WEB-INF/beans.xml
+++ b/guardrails/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
## Summary

Adds an example demonstrating LangChain4j Guardrails support with the WildFly AI Feature Pack.
`@RegisterAIService` already exposes `inputGuardrails`/`outputGuardrails` (by class) and
`inputGuardrailNames`/`outputGuardrailNames` (by CDI bean name) via `langchain4j-cdi` — no
subsystem or Galleon layer change is needed, it works with any existing chat model layer.

- New `guardrails` example: an input guardrail that rejects disallowed messages before the model
  is ever called, and an output guardrail that rewrites an overly long response instead of just
  failing it
- A `GuardrailExceptionMapper` mapping a rejected guardrail to HTTP 422 instead of a generic 500
- A `README.md` in the example documenting what it shows, prerequisites, how to build/run it, and
  copy-pasteable curl commands to verify all three behaviors (normal request, blocked input,
  rewritten output)
- A new "Guardrails" section in the main `README.md` documenting the annotation attributes,
  linked from the supported-AI-types list

## Test plan

- [x] `mvn compile` — builds clean
- [x] `mvn wildfly:dev` — provisions and deploys against a local WildFly + Ollama (`llama3.1:8b`)
- [x] Normal request passes through and gets a real model response
- [x] Message containing a disallowed word is rejected with HTTP 422, without calling the model
- [x] A response longer than 500 characters comes back truncated with a
      `(truncated by output guardrail)` marker, confirming the output guardrail rewrites rather
      than rejects
- [x] Verified against the exact curl commands documented in the example's `README.md`

