### PR TITLE
chore(deps): bump lc4j to 1.19.0/cdi 1.4.0 and adapt MCP SSE transpor…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,23 +60,23 @@
         <version.com.azure.azure-xml>1.2.1</version.com.azure.azure-xml>
         <version.com.dylibso.chicory>1.7.5</version.com.dylibso.chicory>
         <version.com.fasterxml.classmate>1.7.0</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson.annotations>2.21</version.com.fasterxml.jackson.annotations>
-        <version.com.fasterxml.jackson.core>2.21.3</version.com.fasterxml.jackson.core>
+        <version.com.fasterxml.jackson.annotations>2.22</version.com.fasterxml.jackson.annotations>
+        <version.com.fasterxml.jackson.core>2.22.1</version.com.fasterxml.jackson.core>
         <version.com.github.victools.jsonschema-generator>4.38.0</version.com.github.victools.jsonschema-generator>
         <version.com.google.apis>v1-rev20240821-2.0.0</version.com.google.apis>
         <version.com.knuddels.jtokkit>1.1.0</version.com.knuddels.jtokkit>
         <version.com.microsoft.onnxruntime>1.22.0</version.com.microsoft.onnxruntime>
-        <version.com.squareup.okhttp>5.1.0</version.com.squareup.okhttp>
-        <version.com.squareup.okio-jvm>3.6.0</version.com.squareup.okio-jvm>
+        <version.com.squareup.okhttp>5.3.2</version.com.squareup.okhttp>
+        <version.com.squareup.okio-jvm>3.16.4</version.com.squareup.okio-jvm>
         <version.com.squareup.retrofit2>2.11.0</version.com.squareup.retrofit2>
         <version.commons-compress>1.27.1</version.commons-compress>
-        <version.dev.langchain4j>1.17.0-beta27</version.dev.langchain4j>
-        <version.dev.langchain4j.cdi>1.3.4</version.dev.langchain4j.cdi>
-        <version.dev.langchain4j.community>1.17.0-beta27</version.dev.langchain4j.community>
-        <version.dev.langchain4j.core>1.17.0</version.dev.langchain4j.core>
-        <version.dev.langchain4j.embeddings>1.17.0-beta27</version.dev.langchain4j.embeddings>
-        <version.io.projectreactor.netty>1.2.10</version.io.projectreactor.netty>
-        <version.io.projectreactor.reactor-core>3.7.14</version.io.projectreactor.reactor-core>
+        <version.dev.langchain4j>1.19.0-beta29</version.dev.langchain4j>
+        <version.dev.langchain4j.cdi>1.4.0</version.dev.langchain4j.cdi>
+        <version.dev.langchain4j.community>1.18.0-beta28</version.dev.langchain4j.community>
+        <version.dev.langchain4j.core>1.19.0</version.dev.langchain4j.core>
+        <version.dev.langchain4j.embeddings>1.19.0-beta29</version.dev.langchain4j.embeddings>
+        <version.io.projectreactor.netty>1.2.16</version.io.projectreactor.netty>
+        <version.io.projectreactor.reactor-core>3.7.17</version.io.projectreactor.reactor-core>
         <version.io.weaviate.client>5.3.0</version.io.weaviate.client>
         <version.net.java.dev.jna>5.13.0</version.net.java.dev.jna>
         <version.org.extism.sdk.chicory-sdk>0.3.0</version.org.extism.sdk.chicory-sdk>

--- a/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientSseServiceConfigurator.java
+++ b/wildfly-ai/subsystem/src/main/java/org/wildfly/extension/ai/mcp/client/McpClientSseServiceConfigurator.java
@@ -14,7 +14,7 @@ import static org.wildfly.extension.ai.mcp.client.McpClientSseProviderRegistrar.
 
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
-import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -46,11 +46,11 @@ public class McpClientSseServiceConfigurator implements ResourceServiceConfigura
             public WildFlyMcpClient get() {
                 try {
                     URI url = new URI(scheme, null, outboundSocketBinding.get().getUnresolvedDestinationAddress(), outboundSocketBinding.get().getDestinationPort(), path, null, null);
-                    McpTransport transport = new HttpMcpTransport.Builder()
-                            .logRequests(logRequests)
-                            .logResponses(logResponses)
+                    McpTransport transport = new StreamableHttpMcpTransport.Builder()
+                            .logRequests(Boolean.TRUE.equals(logRequests))
+                            .logResponses(Boolean.TRUE.equals(logResponses))
                             .timeout(connectTimeOut > 0L ? Duration.ofMillis(connectTimeOut) : null)
-                            .sseUrl(url.toString())
+                            .url(url.toString())
                             .build();
                     return new WildFlyMcpClient(new DefaultMcpClient.Builder()
                             .transport(transport)


### PR DESCRIPTION
…t API

- HttpMcpTransport replaced by StreamableHttpMcpTransport; sseUrl() → url()